### PR TITLE
pre-commit ruff was conflicting with local ruff. fixed.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,10 +9,16 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
 
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.0.230"
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.1.5
     hooks:
+      # Run the linter.
       - id: ruff
+        args: [ --fix ]
+      # Run the formatter.
+      # Disabled for now, we use black
+      # - id: ruff-format
 
   - repo: https://github.com/psf/black
     rev: "22.8.0"


### PR DESCRIPTION
Change the pre-commit to use hook from the ruff developer team.