### PR TITLE
Add verbose and pretty flags to hkcli.

### DIFF
--- a/heisskleber/console/sink.py
+++ b/heisskleber/console/sink.py
@@ -1,33 +1,33 @@
 import json
-import sys
 import time
-from typing import TextIO
 
 from heisskleber.core.types import AsyncSink, Serializable, Sink
 
 
-def pretty_print(data: dict[str, Serializable]) -> str:
-    return json.dumps(data, indent=4)
-
-
 class ConsoleSink(Sink):
-    def __init__(self, stream: TextIO = sys.stdout, pretty: bool = False):
-        self.stream = stream
-        self.print = pretty_print if pretty else json.dumps
+    def __init__(self, pretty: bool = False, verbose: bool = False) -> None:
+        self.verbose = verbose
+        self.pretty = pretty
 
     def send(self, data: dict[str, Serializable], topic: str) -> None:
-        self.stream.write(self.print(data))  # type: ignore[operator]
-        self.stream.write("\n")
+        verbose_topic = topic + ":\t" if self.verbose else ""
+        if self.pretty:
+            print(verbose_topic + json.dumps(data, indent=4))
+        else:
+            print(verbose_topic + str(data))
 
 
 class AsyncConsoleSink(AsyncSink):
-    def __init__(self, stream: TextIO = sys.stdout, pretty: bool = False):
-        self.stream = stream
-        self.print = pretty_print if pretty else json.dumps
+    def __init__(self, pretty: bool = False, verbose: bool = False) -> None:
+        self.verbose = verbose
+        self.pretty = pretty
 
     async def send(self, data: dict[str, Serializable], topic: str) -> None:
-        self.stream.write(self.print(data))  # type: ignore[operator]
-        self.stream.write("\n")
+        verbose_topic = topic + ":\t" if self.verbose else ""
+        if self.pretty:
+            print(verbose_topic + json.dumps(data, indent=4))
+        else:
+            print(verbose_topic + str(data))
 
 
 if __name__ == "__main__":

--- a/heisskleber/run/cli.py
+++ b/heisskleber/run/cli.py
@@ -11,10 +11,12 @@ TopicType = Union[str, list[str]]
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--type", type=str, choices=["zmq", "mqtt", "serial", "udp"], default="zmq")
-    parser.add_argument("--topic", type=str, default="#")
-    parser.add_argument("--host", type=str, default="localhost")
-    parser.add_argument("--port", type=int, default=1883)
+    parser.add_argument("-t", "--type", type=str, choices=["zmq", "mqtt", "serial", "udp"], default="zmq")
+    parser.add_argument("-T", "--topic", type=str, default="#")
+    parser.add_argument("-H", "--host", type=str, default="localhost")
+    parser.add_argument("-P", "--port", type=int, default=1883)
+    parser.add_argument("-v", "--verbose", action="store_true")
+    parser.add_argument("--pretty", action="store_true")
 
     return parser.parse_args()
 
@@ -22,7 +24,7 @@ def parse_args() -> argparse.Namespace:
 def run() -> None:
     args = parse_args()
     # source = get_source(args.type, args.topic)
-    sink = ConsoleSink()
+    sink = ConsoleSink(pretty=args.pretty, verbose=args.verbose)
 
     sub_cls, conf_cls = _registered_sources[args.type]
 

--- a/heisskleber/run/cli.py
+++ b/heisskleber/run/cli.py
@@ -10,20 +10,47 @@ TopicType = Union[str, list[str]]
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-t", "--type", type=str, choices=["zmq", "mqtt", "serial", "udp"], default="zmq")
-    parser.add_argument("-T", "--topic", type=str, default="#")
-    parser.add_argument("-H", "--host", type=str, default="localhost")
-    parser.add_argument("-P", "--port", type=int, default=1883)
+    parser = argparse.ArgumentParser(
+        prog="hkcli",
+        description="Heisskleber command line interface",
+        usage="%(prog)s [options]",
+    )
+    parser.add_argument(
+        "-t",
+        "--type",
+        type=str,
+        choices=["zmq", "mqtt", "serial", "udp"],
+        default="zmq",
+    )
+    parser.add_argument(
+        "-T",
+        "--topic",
+        type=str,
+        default="#",
+        help="Topic to subscribe to, valid for zmq and mqtt only.",
+    )
+    parser.add_argument(
+        "-H",
+        "--host",
+        type=str,
+        default="localhost",
+        help="Host or broker for MQTT, zmq and UDP.",
+    )
+    parser.add_argument(
+        "-P",
+        "--port",
+        type=int,
+        default=1883,
+        help="Port or serial interface for MQTT, zmq and UDP.",
+    )
     parser.add_argument("-v", "--verbose", action="store_true")
-    parser.add_argument("--pretty", action="store_true")
+    parser.add_argument("-p", "--pretty", action="store_true", help="Pretty print JSON data.")
 
     return parser.parse_args()
 
 
 def run() -> None:
     args = parse_args()
-    # source = get_source(args.type, args.topic)
     sink = ConsoleSink(pretty=args.pretty, verbose=args.verbose)
 
     sub_cls, conf_cls = _registered_sources[args.type]

--- a/tests/test_console_sink.py
+++ b/tests/test_console_sink.py
@@ -1,0 +1,49 @@
+import pytest
+
+from heisskleber.console.sink import AsyncConsoleSink, ConsoleSink
+
+
+def test_console_sink(capsys) -> None:
+    sink = ConsoleSink()
+    sink.send({"key": 3}, "test")
+
+    captured = capsys.readouterr()
+
+    assert captured.out == "{'key': 3}\n"
+
+
+def test_console_sink_verbose(capsys) -> None:
+    sink = ConsoleSink(verbose=True)
+    sink.send({"key": 3}, "test")
+
+    captured = capsys.readouterr()
+
+    assert captured.out == "test:\t{'key': 3}\n"
+
+
+def test_console_sink_pretty(capsys) -> None:
+    sink = ConsoleSink(pretty=True)
+    sink.send({"key": 3}, "test")
+
+    captured = capsys.readouterr()
+
+    assert captured.out == '{\n    "key": 3\n}\n'
+
+
+def test_console_sink_pretty_verbose(capsys) -> None:
+    sink = ConsoleSink(pretty=True, verbose=True)
+    sink.send({"key": 3}, "test")
+
+    captured = capsys.readouterr()
+
+    assert captured.out == 'test:\t{\n    "key": 3\n}\n'
+
+
+@pytest.mark.asyncio
+async def test_async_console_sink(capsys) -> None:
+    sink = AsyncConsoleSink()
+    await sink.send({"key": 3}, "test")
+
+    captured = capsys.readouterr()
+
+    assert captured.out == "{'key': 3}\n"


### PR DESCRIPTION
Changes to ConsoleSink and hkcli commandline tool:
1. "--pretty" argument pretty prints the received json data
2. "-v", "--verbose" argument adds topic to console output.

Adds unittests for Console sink. ConsoleSink now uses builtin print function instead of sys.stoud.write.
Closes #67.