### PR TITLE
Fix/resampler typecheck

### DIFF
--- a/heisskleber/stream/resampler.py
+++ b/heisskleber/stream/resampler.py
@@ -36,12 +36,12 @@ def interpolate(t1: float, y1: list[float], t2: float, y2: list[float], t_target
     return interpolated_values.tolist()
 
 
-def filter_dict(data: dict[str, Serializable]) -> dict[str, int | float]:
+def check_dict(data: dict[str, Serializable]) -> None:
+    """Check that only numeric types are in input data."""
     for key, value in data.items():
         if not isinstance(value, (int, float)):
-            data.pop(key)
-
-    return data
+            error_msg = f"Value {value} for key {key} is not of type int or float"
+            raise TypeError(error_msg)
 
 
 class Resampler:
@@ -74,7 +74,7 @@ class Resampler:
         self.subscriber = subscriber
         self.resample_rate = self.config.resample_rate
         self.delta_t = round(self.resample_rate / 1_000, 3)
-        self.message_queue: Queue[dict[str, Serializable]] = Queue(maxsize=50)
+        self.message_queue: Queue[dict[str, float]] = Queue(maxsize=50)
         self.resample_task: None | Task[None] = None
 
     def start(self) -> None:
@@ -90,7 +90,7 @@ class Resampler:
         if self.resample_task:
             self.resample_task.cancel()
 
-    async def receive(self) -> dict[str, Serializable]:
+    async def receive(self) -> dict[str, float]:
         """
         Get next resampled dictonary from the resampler.
 
@@ -116,7 +116,9 @@ class Resampler:
         # Get first element to determine timestamp
         topic, data = await self.subscriber.receive()
 
-        timestamp, message = self._pack_data(filter_dict(data))
+        check_dict(data)
+
+        timestamp, message = self._pack_data(data)  # type: ignore [arg-type]
         timestamps = timestamp_generator(timestamp, self.resample_rate)
         print(f"Got first element {topic}: {data}")
 
@@ -131,11 +133,9 @@ class Resampler:
             while timestamp < next_timestamp:
                 aggregated_timestamps.append(timestamp)
                 aggregated_data.append(message)
-                # timestamp, message = await self.buffer.get()
 
                 topic, data = await self.subscriber.receive()
-                filter_dict(data)
-                timestamp, message = self._pack_data(filter_dict(data))
+                timestamp, message = self._pack_data(data)  # type: ignore [arg-type]
 
             return_timestamp = round(next_timestamp - self.delta_t / 2, 3)
 
@@ -173,8 +173,6 @@ class Resampler:
                         return_timestamp,
                     )
                 last_timestamp = return_timestamp
-                # else:
-                #     return_timestamp += self.delta_t
 
                 await self.message_queue.put(self._unpack_data(last_timestamp, last_message))
 
@@ -187,11 +185,11 @@ class Resampler:
             aggregated_data.clear()
             aggregated_timestamps.clear()
 
-    def _pack_data(self, data: dict[str, int | float]) -> tuple[float, list[int | float]]:
+    def _pack_data(self, data: dict[str, float]) -> tuple[float, list[float]]:
         # pack data from dict to tuple list
         ts = data.pop("epoch")
         return (ts, list(data.values()))
 
-    def _unpack_data(self, ts: float, values: list[int | float]) -> dict[str, int | float]:
+    def _unpack_data(self, ts: float, values: list[float]) -> dict[str, float]:
         # from tuple
         return {"epoch": round(ts, 3), **dict(zip(self.data_keys, values))}

--- a/heisskleber/stream/resampler.py
+++ b/heisskleber/stream/resampler.py
@@ -28,35 +28,76 @@ def timestamp_generator(start_epoch: float, timedelta_in_ms: int) -> Generator[f
         next_timestamp += delta
 
 
-def interpolate(t1, y1, t2, y2, t_target) -> list[float]:
+def interpolate(t1: float, y1: list[float], t2: float, y2: list[float], t_target: float) -> list[float]:
     """Perform linear interpolation between two data points."""
-    y1, y2 = np.array(y1), np.array(y2)
+    y1_array, y2_array = np.array(y1), np.array(y2)
     fraction = (t_target - t1) / (t2 - t1)
-    interpolated_values = y1 + fraction * (y2 - y1)
+    interpolated_values = y1_array + fraction * (y2_array - y1_array)
     return interpolated_values.tolist()
+
+
+def filter_dict(data: dict[str, Serializable]) -> dict[str, int | float]:
+    for key, value in data.items():
+        if not isinstance(value, (int, float)):
+            data.pop(key)
+
+    return data
 
 
 class Resampler:
     """
     Async resample data based on a fixed rate. Can handle upsampling and downsampling.
 
-    Parameters:
-    ----------
-    config : namedtuple
-        Configuration for the resampler.
-    subscriber : AsyncMQTTSubscriber
-        Asynchronous Subscriber
+    Methods:
+    --------
+    start()
+        Start the resampler task.
+
+    stop()
+        Stop the resampler task.
+
+    receive()
+        Get next resampled dictonary from the resampler.
     """
 
     def __init__(self, config: ResamplerConf, subscriber: AsyncSource) -> None:
+        """
+        Parameters:
+        ----------
+        config : namedtuple
+            Configuration for the resampler.
+        subscriber : AsyncMQTTSubscriber
+            Asynchronous Subscriber
+
+        """
         self.config = config
         self.subscriber = subscriber
         self.resample_rate = self.config.resample_rate
         self.delta_t = round(self.resample_rate / 1_000, 3)
         self.message_queue: Queue[dict[str, Serializable]] = Queue(maxsize=50)
-        self.resample_task: Task = create_task(self.resample())
+        self.resample_task: None | Task[None] = None
+
+    def start(self) -> None:
+        """
+        Start the resampler task.
+        """
+        self.resample_task = create_task(self.resample())
+
+    def stop(self) -> None:
+        """
+        Stop the resampler task
+        """
+        if self.resample_task:
+            self.resample_task.cancel()
 
     async def receive(self) -> dict[str, Serializable]:
+        """
+        Get next resampled dictonary from the resampler.
+
+        Implicitly starts the resampler if not already running.
+        """
+        if not self.resample_task:
+            self.start()
         return await self.message_queue.get()
 
     async def resample(self) -> None:
@@ -74,10 +115,8 @@ class Resampler:
 
         # Get first element to determine timestamp
         topic, data = await self.subscriber.receive()
-        if "datetime" in data:
-            data.pop("datetime")
 
-        timestamp, message = self._pack_data(data)
+        timestamp, message = self._pack_data(filter_dict(data))
         timestamps = timestamp_generator(timestamp, self.resample_rate)
         print(f"Got first element {topic}: {data}")
 
@@ -95,9 +134,8 @@ class Resampler:
                 # timestamp, message = await self.buffer.get()
 
                 topic, data = await self.subscriber.receive()
-                if "datetime" in data:
-                    data.pop("datetime")
-                timestamp, message = self._pack_data(data)
+                filter_dict(data)
+                timestamp, message = self._pack_data(filter_dict(data))
 
             return_timestamp = round(next_timestamp - self.delta_t / 2, 3)
 
@@ -149,11 +187,11 @@ class Resampler:
             aggregated_data.clear()
             aggregated_timestamps.clear()
 
-    def _pack_data(self, data) -> tuple[int, list]:
+    def _pack_data(self, data: dict[str, int | float]) -> tuple[float, list[int | float]]:
         # pack data from dict to tuple list
         ts = data.pop("epoch")
         return (ts, list(data.values()))
 
-    def _unpack_data(self, ts, values) -> dict:
+    def _unpack_data(self, ts: float, values: list[int | float]) -> dict[str, int | float]:
         # from tuple
         return {"epoch": round(ts, 3), **dict(zip(self.data_keys, values))}


### PR DESCRIPTION
To avoid weird behavior when trying to resample a stream that includes non-numeric types, Resampler now does a single pass when receiving the first data. If any non-numeric data is present, a TypeError is raised.

Closes #70.