### PR TITLE
Add reconnection to mqtt async publisher and limit queue size.

### DIFF
--- a/heisskleber/mqtt/publisher_async.py
+++ b/heisskleber/mqtt/publisher_async.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any
+from asyncio import Queue, Task, create_task
 
 import aiomqtt
 
 from heisskleber.core.packer import get_packer
-from heisskleber.core.types import AsyncSink
+from heisskleber.core.types import AsyncSink, Serializable
 
 from .config import MqttConf
 
@@ -22,10 +22,10 @@ class AsyncMqttPublisher(AsyncSink):
     def __init__(self, config: MqttConf) -> None:
         self.config = config
         self.pack = get_packer(config.packstyle)
-        self._send_queue = asyncio.Queue()
-        self._sender_task = asyncio.create_task(self.send_work())
+        self._send_queue: Queue[tuple[dict[str, Serializable], str]] = Queue(maxsize=config.max_saved_messages)
+        self._sender_task: Task[None] = create_task(self.send_work())
 
-    async def send(self, data: dict[str, Any], topic: str) -> None:
+    async def send(self, data: dict[str, Serializable], topic: str) -> None:
         """
         Takes python dictionary, serializes it according to the packstyle
         and sends it to the broker.
@@ -42,10 +42,19 @@ class AsyncMqttPublisher(AsyncSink):
 
         Publishing is asynchronous
         """
-        async with aiomqtt.Client(
-            hostname=self.config.broker, port=self.config.port, username=self.config.user, password=self.config.password
-        ) as client:
-            while True:
-                data, topic = await self._send_queue.get()
-                payload = self.pack(data)
-                await client.publish(topic, payload)
+        while True:
+            try:
+                async with aiomqtt.Client(
+                    hostname=self.config.broker,
+                    port=self.config.port,
+                    username=self.config.user,
+                    password=self.config.password,
+                    timeout=float(self.config.timeout_s),
+                ) as client:
+                    while True:
+                        data, topic = await self._send_queue.get()
+                        payload = self.pack(data)
+                        await client.publish(topic, payload)
+            except aiomqtt.MqttError:
+                print("Connection to MQTT broker failed. Retrying in 5 seconds")
+                await asyncio.sleep(5)


### PR DESCRIPTION
This PR fixes #65, caused by an unlimited queue that is filled with send() calls, while the background mqtt loop is not establishing a connection. 

The fix is two-fold: 
1. The queue size now is limited to a configurable max number of messages
2. The mqtt connection is re-established after 5 seconds when a connection fails. 