### PR TITLE
Refactor/background tasks

### DIFF
--- a/config/heisskleber/mqtt.yaml
+++ b/config/heisskleber/mqtt.yaml
@@ -1,4 +1,4 @@
-broker: "10.47.36.1"
+host: "10.47.36.1"
 user: ""
 password: ""
 port: 1883

--- a/config/heisskleber/zmq.yaml
+++ b/config/heisskleber/zmq.yaml
@@ -1,4 +1,4 @@
-protocol : "tcp"  # ipc protocol
-interface: "127.0.0.1"  # the interface to bind to
-publisher_port : 5555  # port used by primary producers
-subscriber_port: 5556  # port used by primary consumers
+protocol: "tcp" # ipc protocol
+host: "127.0.0.1" # the interface to bind to
+publisher_port: 5555 # port used by primary producers
+subscriber_port: 5556 # port used by primary consumers

--- a/heisskleber/config/__init__.py
+++ b/heisskleber/config/__init__.py
@@ -1,4 +1,4 @@
 from .config import BaseConf
-from .parse import load_config
+from .parse import ConfigType, load_config
 
-__all__ = ["load_config", "BaseConf"]
+__all__ = ["load_config", "BaseConf", "ConfigType"]

--- a/heisskleber/console/sink.py
+++ b/heisskleber/console/sink.py
@@ -16,6 +16,15 @@ class ConsoleSink(Sink):
         else:
             print(verbose_topic + str(data))
 
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(pretty={self.pretty}, verbose={self.verbose})"
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
 
 class AsyncConsoleSink(AsyncSink):
     def __init__(self, pretty: bool = False, verbose: bool = False) -> None:
@@ -28,6 +37,15 @@ class AsyncConsoleSink(AsyncSink):
             print(verbose_topic + json.dumps(data, indent=4))
         else:
             print(verbose_topic + str(data))
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(pretty={self.pretty}, verbose={self.verbose})"
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
 
 
 if __name__ == "__main__":

--- a/heisskleber/console/source.py
+++ b/heisskleber/console/source.py
@@ -1,34 +1,98 @@
+import asyncio
 import json
 import sys
 import time
 from queue import SimpleQueue
 from threading import Thread
 
-from heisskleber.core.types import Serializable, Source
+from heisskleber.core.types import AsyncSource, Serializable, Source
 
 
 class ConsoleSource(Source):
-    def __init__(self, topic: str | list[str] | tuple[str] = "console") -> None:
-        self.topic = "console"
+    def __init__(self, topic: str = "console") -> None:
+        self.topic = topic
         self.queue = SimpleQueue()
-        self.listener_daemon = Thread(target=self.listener_task, daemon=True)
-        self.listener_daemon.start()
         self.pack = json.loads
+        self.thread: Thread | None = None
 
     def listener_task(self):
         while True:
-            data = sys.stdin.readline()
-            payload = self.pack(data)
-            self.queue.put(payload)
+            try:
+                data = sys.stdin.readline()
+                payload = self.pack(data)
+                self.queue.put(payload)
+            except json.decoder.JSONDecodeError:
+                print("Invalid JSON")
+                continue
+            except ValueError:
+                break
+        print("listener task finished")
 
     def receive(self) -> tuple[str, dict[str, Serializable]]:
+        if not self.thread:
+            self.start()
+
         data = self.queue.get()
         return self.topic, data
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(topic={self.topic})"
+
+    def start(self) -> None:
+        self.thread = Thread(target=self.listener_task, daemon=True)
+        self.thread.start()
+
+    def stop(self) -> None:
+        if self.thread:
+            sys.stdin.close()
+            self.thread.join()
+
+
+class AsyncConsoleSource(AsyncSource):
+    def __init__(self, topic: str = "console") -> None:
+        self.topic = topic
+        self.queue: asyncio.Queue[dict[str, Serializable]] = asyncio.Queue(maxsize=10)
+        self.pack = json.loads
+        self.task: asyncio.Task[None] | None = None
+
+    async def listener_task(self):
+        while True:
+            data = sys.stdin.readline()
+            payload = self.pack(data)
+            await self.queue.put(payload)
+
+    async def receive(self) -> tuple[str, dict[str, Serializable]]:
+        if not self.task:
+            self.start()
+
+        data = await self.queue.get()
+        return self.topic, data
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(topic={self.topic})"
+
+    def start(self) -> None:
+        self.task = asyncio.create_task(self.listener_task())
+
+    def stop(self) -> None:
+        if self.task:
+            self.task.cancel()
 
 
 if __name__ == "__main__":
     console_source = ConsoleSource()
+    console_source.start()
 
-    while True:
-        print(console_source.receive())
-        time.sleep(1)
+    print("Listening to console input.")
+
+    count = 0
+
+    try:
+        while True:
+            print(console_source.receive())
+            time.sleep(1)
+            count += 1
+            print(count)
+    except KeyboardInterrupt:
+        print("Stopped")
+        sys.exit(0)

--- a/heisskleber/core/types.py
+++ b/heisskleber/core/types.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any, Callable, Union
 
-from heisskleber.config.config import BaseConf
+from heisskleber.config import BaseConf
 
 Serializable = Union[str, int, float]
 
@@ -23,7 +23,7 @@ class Sink(ABC):
         pass
 
     @abstractmethod
-    def send(self, data: dict[str, Any], topic: str) -> None:
+    def send(self, data: dict[str, Serializable], topic: str) -> None:
         """
         Send data via the implemented output stream.
         """

--- a/heisskleber/core/types.py
+++ b/heisskleber/core/types.py
@@ -29,6 +29,24 @@ class Sink(ABC):
         """
         pass
 
+    @abstractmethod
+    def __repr__(self) -> str:
+        pass
+
+    @abstractmethod
+    def start(self) -> None:
+        """
+        Start any background processes and tasks.
+        """
+        pass
+
+    @abstractmethod
+    def stop(self) -> None:
+        """
+        Stop any background processes and tasks.
+        """
+        pass
+
 
 class Source(ABC):
     """
@@ -53,25 +71,21 @@ class Source(ABC):
         """
         pass
 
-
-class AsyncSubscriber(ABC):
-    """
-    AsyncSubscriber interface
-    """
+    @abstractmethod
+    def __repr__(self) -> str:
+        pass
 
     @abstractmethod
-    def __init__(self, config: Any, topic: str | list[str]) -> None:
+    def start(self) -> None:
         """
-        Initialize the subscriber with a topic and a configuration object.
+        Start any background processes and tasks.
         """
         pass
 
     @abstractmethod
-    async def receive(self) -> tuple[str, dict[str, Serializable]]:
+    def stop(self) -> None:
         """
-        Blocking function to receive data from the implemented input stream.
-
-        Data is returned as a tuple of (topic, data).
+        Stop any background processes and tasks.
         """
         pass
 
@@ -97,6 +111,24 @@ class AsyncSource(ABC):
         """
         pass
 
+    @abstractmethod
+    def __repr__(self) -> str:
+        pass
+
+    @abstractmethod
+    def start(self) -> None:
+        """
+        Start any background processes and tasks.
+        """
+        pass
+
+    @abstractmethod
+    def stop(self) -> None:
+        """
+        Stop any background processes and tasks.
+        """
+        pass
+
 
 class AsyncSink(ABC):
     """
@@ -116,5 +148,23 @@ class AsyncSink(ABC):
     async def send(self, data: dict[str, Any], topic: str) -> None:
         """
         Send data via the implemented output stream.
+        """
+        pass
+
+    @abstractmethod
+    def __repr__(self) -> str:
+        pass
+
+    @abstractmethod
+    def start(self) -> None:
+        """
+        Start any background processes and tasks.
+        """
+        pass
+
+    @abstractmethod
+    def stop(self) -> None:
+        """
+        Stop any background processes and tasks.
         """
         pass

--- a/heisskleber/mqtt/config.py
+++ b/heisskleber/mqtt/config.py
@@ -9,7 +9,7 @@ class MqttConf(BaseConf):
     MQTT configuration class.
     """
 
-    broker: str = "localhost"
+    host: str = "localhost"
     user: str = ""
     password: str = ""
     port: int = 1883

--- a/heisskleber/mqtt/mqtt_base.py
+++ b/heisskleber/mqtt/mqtt_base.py
@@ -58,7 +58,7 @@ class MqttBase:
             # the default certification authority of the system is used.
             self.client.tls_set(tls_version=ssl.PROTOCOL_TLS_CLIENT)
 
-        self.client.connect(self.config.broker, self.config.port)
+        self.client.connect(self.config.host, self.config.port)
         self.client.loop_start()
 
     @staticmethod
@@ -70,7 +70,7 @@ class MqttBase:
     # MQTT callbacks
     def _on_connect(self, client, userdata, flags, return_code) -> None:
         if return_code == 0:
-            print(f"MQTT node connected to {self.config.broker}:{self.config.port}")
+            print(f"MQTT node connected to {self.config.host}:{self.config.port}")
         else:
             print("Connection failed!")
         if self.config.verbose:

--- a/heisskleber/mqtt/mqtt_base.py
+++ b/heisskleber/mqtt/mqtt_base.py
@@ -34,8 +34,14 @@ class MqttBase:
 
     def __init__(self, config: MqttConf) -> None:
         self.config = config
+        self.client: mqtt_client | None = None
+
+    def start(self) -> None:
         self.connect()
-        self.client.loop_start()
+
+    def stop(self) -> None:
+        if self.client:
+            self.client.loop_stop()
 
     def connect(self) -> None:
         self.client = mqtt_client()
@@ -53,6 +59,7 @@ class MqttBase:
             self.client.tls_set(tls_version=ssl.PROTOCOL_TLS_CLIENT)
 
         self.client.connect(self.config.broker, self.config.port)
+        self.client.loop_start()
 
     @staticmethod
     def _raise_if_thread_died() -> None:
@@ -84,4 +91,4 @@ class MqttBase:
             print(f"Received message: {message.payload!s}, topic: {message.topic}, qos: {message.qos}")
 
     def __del__(self) -> None:
-        self.client.loop_stop()
+        self.stop()

--- a/heisskleber/mqtt/publisher.py
+++ b/heisskleber/mqtt/publisher.py
@@ -35,7 +35,7 @@ class MqttPublisher(MqttBase, Sink):
         self.client.publish(topic, payload, qos=self.config.qos, retain=self.config.retain)
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(broker={self.config.broker}, port={self.config.port})"
+        return f"{self.__class__.__name__}(broker={self.config.host}, port={self.config.port})"
 
     def start(self) -> None:
         super().start()

--- a/heisskleber/mqtt/publisher.py
+++ b/heisskleber/mqtt/publisher.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
-from typing import Any
-
 from heisskleber.core.packer import get_packer
-from heisskleber.core.types import Sink
+from heisskleber.core.types import Serializable, Sink
 
 from .config import MqttConf
 from .mqtt_base import MqttBase
@@ -21,14 +19,26 @@ class MqttPublisher(MqttBase, Sink):
         super().__init__(config)
         self.pack = get_packer(config.packstyle)
 
-    def send(self, data: dict[str, Any], topic: str) -> None:
+    def send(self, data: dict[str, Serializable], topic: str) -> None:
         """
         Takes python dictionary, serializes it according to the packstyle
         and sends it to the broker.
 
         Publishing is asynchronous
         """
+        if not self.client.is_connected():
+            self.start()
+
         self._raise_if_thread_died()
 
         payload = self.pack(data)
         self.client.publish(topic, payload, qos=self.config.qos, retain=self.config.retain)
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(broker={self.config.broker}, port={self.config.port})"
+
+    def start(self) -> None:
+        super().start()
+
+    def stop(self) -> None:
+        super().stop()

--- a/heisskleber/mqtt/publisher_async.py
+++ b/heisskleber/mqtt/publisher_async.py
@@ -44,7 +44,7 @@ class AsyncMqttPublisher(AsyncSink):
         while True:
             try:
                 async with aiomqtt.Client(
-                    hostname=self.config.broker,
+                    hostname=self.config.host,
                     port=self.config.port,
                     username=self.config.user,
                     password=self.config.password,
@@ -59,7 +59,7 @@ class AsyncMqttPublisher(AsyncSink):
                 await sleep(5)
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(broker={self.config.broker}, port={self.config.port})"
+        return f"{self.__class__.__name__}(broker={self.config.host}, port={self.config.port})"
 
     def start(self) -> None:
         self._sender_task = create_task(self.send_work())

--- a/heisskleber/mqtt/publisher_async.py
+++ b/heisskleber/mqtt/publisher_async.py
@@ -1,7 +1,4 @@
-from __future__ import annotations
-
-import asyncio
-from asyncio import Queue, Task, create_task
+from asyncio import Queue, Task, create_task, sleep
 
 import aiomqtt
 
@@ -22,8 +19,8 @@ class AsyncMqttPublisher(AsyncSink):
     def __init__(self, config: MqttConf) -> None:
         self.config = config
         self.pack = get_packer(config.packstyle)
-        self._send_queue: Queue[tuple[dict[str, Serializable], str]] = Queue(maxsize=config.max_saved_messages)
-        self._sender_task: Task[None] = create_task(self.send_work())
+        self._send_queue: Queue[tuple[dict[str, Serializable], str]] = Queue()
+        self._sender_task: Task[None] | None = None
 
     async def send(self, data: dict[str, Serializable], topic: str) -> None:
         """
@@ -32,6 +29,8 @@ class AsyncMqttPublisher(AsyncSink):
 
         Publishing is asynchronous
         """
+        if not self._sender_task:
+            self.start()
 
         await self._send_queue.put((data, topic))
 
@@ -57,4 +56,15 @@ class AsyncMqttPublisher(AsyncSink):
                         await client.publish(topic, payload)
             except aiomqtt.MqttError:
                 print("Connection to MQTT broker failed. Retrying in 5 seconds")
-                await asyncio.sleep(5)
+                await sleep(5)
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(broker={self.config.broker}, port={self.config.port})"
+
+    def start(self) -> None:
+        self._sender_task = create_task(self.send_work())
+
+    def stop(self) -> None:
+        if self._sender_task:
+            self._sender_task.cancel()
+            self._sender_task = None

--- a/heisskleber/mqtt/subscriber.py
+++ b/heisskleber/mqtt/subscriber.py
@@ -58,7 +58,7 @@ class MqttSubscriber(MqttBase, Source):
         return (mqtt_message.topic, message_returned)
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(broker={self.config.broker}, port={self.config.port})"
+        return f"{self.__class__.__name__}(broker={self.config.host}, port={self.config.port})"
 
     def start(self) -> None:
         super().start()

--- a/heisskleber/mqtt/subscriber_async.py
+++ b/heisskleber/mqtt/subscriber_async.py
@@ -16,7 +16,7 @@ class AsyncMqttSubscriber(AsyncSource):
     def __init__(self, config: MqttConf, topic: str | list[str]) -> None:
         self.config: MqttConf = config
         self.client = Client(
-            hostname=self.config.broker,
+            hostname=self.config.host,
             port=self.config.port,
             username=self.config.user,
             password=self.config.password,
@@ -26,7 +26,7 @@ class AsyncMqttSubscriber(AsyncSource):
         self.message_queue: Queue[Message] = Queue(self.config.max_saved_messages)
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(broker={self.config.broker}, port={self.config.port})"
+        return f"{self.__class__.__name__}(broker={self.config.host}, port={self.config.port})"
 
     def start(self) -> None:
         self._listener_task = create_task(self.run())

--- a/heisskleber/udp/config.py
+++ b/heisskleber/udp/config.py
@@ -10,5 +10,6 @@ class UdpConf(BaseConf):
     """
 
     port: int = 1234
-    ip: str = "127.0.0.1"
+    host: str = "127.0.0.1"
     packer: str = "json"
+    max_queue_size: int = 1000

--- a/heisskleber/udp/publisher.py
+++ b/heisskleber/udp/publisher.py
@@ -1,4 +1,5 @@
 import socket
+import sys
 
 from heisskleber.core.packer import get_packer
 from heisskleber.core.types import Serializable, Sink
@@ -8,15 +9,30 @@ from heisskleber.udp.config import UdpConf
 class UdpPublisher(Sink):
     def __init__(self, config: UdpConf) -> None:
         self.config = config
-        self.ip = self.config.ip
+        self.ip = self.config.host
         self.port = self.config.port
-        self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.pack = get_packer(self.config.packer)
+        self.is_connected = False
 
-    def send(self, message: dict[str, Serializable], topic: str) -> None:
-        message["topic"] = topic
-        payload = self.pack(message).encode("utf-8")
+    def start(self) -> None:
+        try:
+            self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        except OSError as e:
+            print(f"failed to create socket: {e}")
+            sys.exit(-1)
+        else:
+            self.is_connected = True
+
+    def stop(self) -> None:
+        self.socket.close()
+        self.is_connected = True
+
+    def send(self, data: dict[str, Serializable], topic: str) -> None:
+        if not self.is_connected:
+            self.start()
+        data["topic"] = topic
+        payload = self.pack(data).encode("utf-8")
         self.socket.sendto(payload, (self.ip, self.port))
 
-    def __del__(self) -> None:
-        self.socket.close()
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(host={self.config.host}, port={self.config.port})"

--- a/heisskleber/zmq/config.py
+++ b/heisskleber/zmq/config.py
@@ -6,15 +6,15 @@ from heisskleber.config import BaseConf
 @dataclass
 class ZmqConf(BaseConf):
     protocol: str = "tcp"
-    interface: str = "127.0.0.1"
+    host: str = "127.0.0.1"
     publisher_port: int = 5555
     subscriber_port: int = 5556
     packstyle: str = "json"
 
     @property
     def publisher_address(self) -> str:
-        return f"{self.protocol}://{self.interface}:{self.publisher_port}"
+        return f"{self.protocol}://{self.host}:{self.publisher_port}"
 
     @property
     def subscriber_address(self) -> str:
-        return f"{self.protocol}://{self.interface}:{self.subscriber_port}"
+        return f"{self.protocol}://{self.host}:{self.subscriber_port}"

--- a/heisskleber/zmq/publisher.py
+++ b/heisskleber/zmq/publisher.py
@@ -1,4 +1,5 @@
 import sys
+from typing import Callable
 
 import zmq
 import zmq.asyncio
@@ -10,45 +11,46 @@ from .config import ZmqConf
 
 
 class ZmqPublisher(Sink):
+    """
+    Publisher that sends messages to a ZMQ PUB socket.
+
+    Attributes:
+    -----------
+    pack : Callable
+        The packer function to use for serializing the data.
+
+    Methods:
+    --------
+    send(data : dict, topic : str):
+        Send the data with the given topic.
+
+    start():
+        Connect to the socket.
+
+    stop():
+        Close the socket.
+    """
+
     def __init__(self, config: ZmqConf):
         self.config = config
-
         self.context = zmq.Context.instance()
         self.socket = self.context.socket(zmq.PUB)
-
         self.pack = get_packer(config.packstyle)
-        self.connect()
-
-    def connect(self) -> None:
-        try:
-            if self.config.verbose:
-                print(f"connecting to {self.config.publisher_address}")
-            self.socket.connect(self.config.publisher_address)
-        except Exception as e:
-            print(f"failed to bind to zeromq socket: {e}")
-            sys.exit(-1)
+        self.is_connected = False
 
     def send(self, data: dict[str, Serializable], topic: str) -> None:
+        """
+        Take the data as a dict, serialize it with the given packer and send it to the zmq socket.
+        """
+        if not self.is_connected:
+            self.start()
         payload = self.pack(data)
         if self.config.verbose:
             print(f"sending message {payload} to topic {topic}")
         self.socket.send_multipart([topic.encode(), payload.encode()])
 
-    def __del__(self):
-        self.socket.close()
-
-
-class ZmqAsyncPublisher(AsyncSink):
-    def __init__(self, config: ZmqConf):
-        self.config = config
-
-        self.context = zmq.asyncio.Context.instance()
-        self.socket: zmq.asyncio.Socket = self.context.socket(zmq.PUB)
-
-        self.pack = get_packer(config.packstyle)
-        self.connect()
-
-    def connect(self) -> None:
+    def start(self) -> None:
+        """Connect to the zmq socket."""
         try:
             if self.config.verbose:
                 print(f"connecting to {self.config.publisher_address}")
@@ -56,12 +58,72 @@ class ZmqAsyncPublisher(AsyncSink):
         except Exception as e:
             print(f"failed to bind to zeromq socket: {e}")
             sys.exit(-1)
+        else:
+            self.is_connected = True
+
+    def stop(self) -> None:
+        self.socket.close()
+        self.is_connected = False
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(host={self.config.publisher_address}, port={self.config.publisher_port})"
+
+
+class ZmqAsyncPublisher(AsyncSink):
+    """
+    Async publisher that sends messages to a ZMQ PUB socket.
+
+    Attributes:
+    -----------
+    pack : Callable
+        The packer function to use for serializing the data.
+
+    Methods:
+    --------
+    send(data : dict, topic : str):
+        Send the data with the given topic.
+
+    start():
+        Connect to the socket.
+
+    stop():
+        Close the socket.
+    """
+
+    def __init__(self, config: ZmqConf):
+        self.config = config
+        self.context = zmq.asyncio.Context.instance()
+        self.socket: zmq.asyncio.Socket = self.context.socket(zmq.PUB)
+        self.pack: Callable = get_packer(config.packstyle)
+        self.is_connected = False
 
     async def send(self, data: dict[str, Serializable], topic: str) -> None:
+        """
+        Take the data as a dict, serialize it with the given packer and send it to the zmq socket.
+        """
+        if not self.is_connected:
+            self.start()
         payload = self.pack(data)
         if self.config.verbose:
             print(f"sending message {payload} to topic {topic}")
         await self.socket.send_multipart([topic.encode(), payload.encode()])
 
-    def __del__(self):
+    def start(self) -> None:
+        """Connect to the zmq socket."""
+        try:
+            if self.config.verbose:
+                print(f"connecting to {self.config.publisher_address}")
+            self.socket.connect(self.config.publisher_address)
+        except Exception as e:
+            print(f"failed to bind to zeromq socket: {e}")
+            sys.exit(-1)
+        else:
+            self.is_connected = True
+
+    def stop(self) -> None:
+        """Close the zmq socket."""
         self.socket.close()
+        self.is_connected = False
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(host={self.config.publisher_address}, port={self.config.publisher_port})"

--- a/heisskleber/zmq/subscriber.py
+++ b/heisskleber/zmq/subscriber.py
@@ -12,34 +12,43 @@ from .config import ZmqConf
 
 
 class ZmqSubscriber(Source):
-    def __init__(self, config: ZmqConf, topic: str):
-        self.config = config
+    """
+    Source that subscribes to one or many topics from a zmq broker and receives messages via the receive() function.
 
+    Attributes:
+    -----------
+    unpack : Callable
+        The unpacker function to use for deserializing the data.
+
+    Methods:
+    --------
+    receive() -> tuple[str, dict]:
+        Send the data with the given topic.
+
+    start():
+        Connect to the socket.
+
+    stop():
+        Close the socket.
+    """
+
+    def __init__(self, config: ZmqConf, topic: str | list[str]):
+        """
+        Constructs new ZmqAsyncSubscriber instance.
+
+        Parameters:
+        -----------
+        config : ZmqConf
+            The configuration dataclass object for the zmq connection.
+        topic : str
+            The topic or list of topics to subscribe to.
+        """
+        self.config = config
+        self.topic = topic
         self.context = zmq.Context.instance()
         self.socket = self.context.socket(zmq.SUB)
-        self.connect()
-        self.subscribe(topic)
-
         self.unpack = get_unpacker(config.packstyle)
-
-    def connect(self):
-        try:
-            # print(f"Connecting to { self.config.consumer_connection }")
-            self.socket.connect(self.config.subscriber_address)
-        except Exception as e:
-            print(f"failed to bind to zeromq socket: {e}")
-            sys.exit(-1)
-
-    def _subscribe_single_topic(self, topic: str):
-        self.socket.setsockopt(zmq.SUBSCRIBE, topic.encode())
-
-    def subscribe(self, topic: str | list[str] | tuple[str]):
-        # Accepts single topic or list of topics
-        if isinstance(topic, (list, tuple)):
-            for t in topic:
-                self._subscribe_single_topic(t)
-        else:
-            self._subscribe_single_topic(topic)
+        self.is_connected = False
 
     def receive(self) -> tuple[str, dict]:
         """
@@ -48,34 +57,26 @@ class ZmqSubscriber(Source):
         Returns:
             tuple(topic: str, message: dict): the message received
         """
+        if not self.is_connected:
+            self.start()
         (topic, payload) = self.socket.recv_multipart()
         message = self.unpack(payload.decode())
         topic = topic.decode()
         return (topic, message)
 
-    def __del__(self):
-        self.socket.close()
-
-
-class ZmqAsyncSubscriber(AsyncSource):
-    def __init__(self, config: ZmqConf, topic: str):
-        self.config = config
-        self.context = zmq.asyncio.Context.instance()
-        self.socket: zmq.asyncio.Socket = self.context.socket(zmq.SUB)
-        self.connect()
-        self.subscribe(topic)
-
-        self.unpack = get_unpacker(config.packstyle)
-
-    def connect(self):
+    def start(self):
         try:
             self.socket.connect(self.config.subscriber_address)
+            self.subscribe(self.topic)
         except Exception as e:
             print(f"failed to bind to zeromq socket: {e}")
             sys.exit(-1)
+        else:
+            self.is_connected = True
 
-    def _subscribe_single_topic(self, topic: str):
-        self.socket.setsockopt(zmq.SUBSCRIBE, topic.encode())
+    def stop(self):
+        self.socket.close()
+        self.is_connected = False
 
     def subscribe(self, topic: str | list[str] | tuple[str]):
         # Accepts single topic or list of topics
@@ -85,6 +86,52 @@ class ZmqAsyncSubscriber(AsyncSource):
         else:
             self._subscribe_single_topic(topic)
 
+    def _subscribe_single_topic(self, topic: str):
+        self.socket.setsockopt(zmq.SUBSCRIBE, topic.encode())
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(host={self.config.subscriber_address}, port={self.config.subscriber_port})"
+
+
+class ZmqAsyncSubscriber(AsyncSource):
+    """
+    Async source that subscribes to one or many topics from a zmq broker and receives messages via the receive() function.
+
+    Attributes:
+    -----------
+    unpack : Callable
+        The unpacker function to use for deserializing the data.
+
+    Methods:
+    --------
+    receive() -> tuple[str, dict]:
+        Send the data with the given topic.
+
+    start():
+        Connect to the socket.
+
+    stop():
+        Close the socket.
+    """
+
+    def __init__(self, config: ZmqConf, topic: str | list[str]):
+        """
+        Constructs new ZmqAsyncSubscriber instance.
+
+        Parameters:
+        -----------
+        config : ZmqConf
+            The configuration dataclass object for the zmq connection.
+        topic : str
+            The topic or list of topics to subscribe to.
+        """
+        self.config = config
+        self.topic = topic
+        self.context = zmq.asyncio.Context.instance()
+        self.socket: zmq.asyncio.Socket = self.context.socket(zmq.SUB)
+        self.unpack = get_unpacker(config.packstyle)
+        self.is_connected = True
+
     async def receive(self) -> tuple[str, dict]:
         """
         reads a message from the zmq bus and returns it
@@ -92,10 +139,43 @@ class ZmqAsyncSubscriber(AsyncSource):
         Returns:
             tuple(topic: str, message: dict): the message received
         """
+        if not self.is_connected:
+            self.start()
         (topic, payload) = await self.socket.recv_multipart()
         message = self.unpack(payload.decode())
         topic = topic.decode()
         return (topic, message)
 
-    def __del__(self):
+    def start(self):
+        """Connect to the zmq socket."""
+        try:
+            self.socket.connect(self.config.subscriber_address)
+        except Exception as e:
+            print(f"failed to bind to zeromq socket: {e}")
+            sys.exit(-1)
+        else:
+            self.is_connected = True
+        self.subscribe(self.topic)
+
+    def stop(self):
+        """Close the zmq socket."""
         self.socket.close()
+        self.is_connected = False
+
+    def subscribe(self, topic: str | list[str] | tuple[str]):
+        """
+        Subscribes to the given topic(s) on the zmq socket.
+
+        Accepts single topic or list of topics.
+        """
+        if isinstance(topic, (list, tuple)):
+            for t in topic:
+                self._subscribe_single_topic(t)
+        else:
+            self._subscribe_single_topic(topic)
+
+    def _subscribe_single_topic(self, topic: str):
+        self.socket.setsockopt(zmq.SUBSCRIBE, topic.encode())
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(host={self.config.subscriber_address}, port={self.config.subscriber_port})"

--- a/run/udp-listener.py
+++ b/run/udp-listener.py
@@ -1,8 +1,8 @@
-from heisskleber.udp import UdpSubscriber, UdpConf
+from heisskleber.udp import UdpConf, UdpSubscriber
 
 
 def main() -> None:
-    conf = UdpConf(ip="192.168.137.1", port=6600)
+    conf = UdpConf(host="192.168.137.1", port=6600)
     subscriber = UdpSubscriber(conf)
 
     while True:
@@ -12,4 +12,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-

--- a/tests/integration/async_streamer.py
+++ b/tests/integration/async_streamer.py
@@ -10,7 +10,7 @@ async def main():
     topic1 = "topic1"
     topic2 = "topic2"
 
-    config = MqttConf(broker="localhost", port=1883, user="", password="")  # not a real password
+    config = MqttConf(host="localhost", port=1883, user="", password="")  # not a real password
     sub1 = AsyncMqttSubscriber(config, topic1)
     sub2 = AsyncMqttSubscriber(config, topic2)
 

--- a/tests/integration/integration_joint.py
+++ b/tests/integration/integration_joint.py
@@ -7,7 +7,7 @@ from heisskleber.stream import Joint, Resampler, ResamplerConf
 async def main():
     topics = ["topic0", "topic1", "topic2", "topic3"]
 
-    config = MqttConf(broker="localhost", port=1883, user="", password="")  # not a real password
+    config = MqttConf(host="localhost", port=1883, user="", password="")  # not a real password
     subs = [AsyncMqttSubscriber(config, topic=topic) for topic in topics]
 
     resampler_config = ResamplerConf(resample_rate=1000)

--- a/tests/integration/mqtt_async.py
+++ b/tests/integration/mqtt_async.py
@@ -4,7 +4,7 @@ from heisskleber.mqtt import AsyncMqttSubscriber, MqttConf
 
 
 async def main():
-    conf = MqttConf(broker="localhost", port=1883, user="", password="")
+    conf = MqttConf(host="localhost", port=1883, user="", password="")
     sub = AsyncMqttSubscriber(conf, topic="#")
     # async for topic, message in sub:
     #     print(message)

--- a/tests/integration/mqtt_pub.py
+++ b/tests/integration/mqtt_pub.py
@@ -20,7 +20,7 @@ async def send_every_n_miliseconds(frequency, value, pub, topic):
 
 
 async def main2():
-    config = MqttConf(broker="localhost", port=1883, user="", password="")
+    config = MqttConf(host="localhost", port=1883, user="", password="")
 
     pubs = [AsyncMqttPublisher(config) for i in range(5)]
     tasks = []

--- a/tests/integration/mqtt_stream.py
+++ b/tests/integration/mqtt_stream.py
@@ -5,7 +5,7 @@ from heisskleber.stream import Resampler, ResamplerConf
 
 
 async def main():
-    conf = MqttConf(broker="localhost", port=1883, user="", password="")
+    conf = MqttConf(host="localhost", port=1883, user="", password="")
     sub = AsyncMqttSubscriber(conf, topic="#")
 
     resampler = Resampler(ResamplerConf(), sub)

--- a/tests/integration/mqtt_sub.py
+++ b/tests/integration/mqtt_sub.py
@@ -4,7 +4,7 @@ from heisskleber.mqtt import AsyncMqttSubscriber, MqttConf
 
 
 async def main():
-    config = MqttConf(broker="localhost", port=1883, user="", password="")
+    config = MqttConf(host="localhost", port=1883, user="", password="")
 
     sub = AsyncMqttSubscriber(config, topic="#")
 

--- a/tests/integration/sync_streamer.py
+++ b/tests/integration/sync_streamer.py
@@ -13,7 +13,7 @@ def main():
     # topic2 = "topic2"
 
     config = MqttConf(
-        broker="localhost", port=1883, user="", password=""
+        host="localhost", port=1883, user="", password=""
     )  # , not a real password port=1883, user="", password="")
     sub1 = MqttSubscriber(config, topic1)
     # sub2 = MqttSubscriber(config, topic2)

--- a/tests/resources/zmq.yaml
+++ b/tests/resources/zmq.yaml
@@ -1,4 +1,4 @@
-protocol : "tcp"  # ipc protocol
-interface: "127.0.0.1"  # the interface to bind to
-publisher_port : 5555  # port used by primary producers
-subscriber_port: 5556  # port used by primary consumers
+protocol: "tcp" # ipc protocol
+host: "127.0.0.1" # the interface to bind to
+publisher_port: 5555 # port used by primary producers
+subscriber_port: 5556 # port used by primary consumers

--- a/tests/test_console_sink.py
+++ b/tests/test_console_sink.py
@@ -39,6 +39,16 @@ def test_console_sink_pretty_verbose(capsys) -> None:
     assert captured.out == 'test:\t{\n    "key": 3\n}\n'
 
 
+def test_console_repr() -> None:
+    sink = ConsoleSink()
+    assert repr(sink) == "ConsoleSink(pretty=False, verbose=False)"
+
+
+def test_async_console_repr() -> None:
+    sink = AsyncConsoleSink()
+    assert repr(sink) == "AsyncConsoleSink(pretty=False, verbose=False)"
+
+
 @pytest.mark.asyncio
 async def test_async_console_sink(capsys) -> None:
     sink = AsyncConsoleSink()

--- a/tests/test_mqtt.py
+++ b/tests/test_mqtt.py
@@ -14,7 +14,7 @@ from heisskleber.mqtt.subscriber import MqttSubscriber
 @pytest.fixture
 def mock_mqtt_conf() -> MqttConf:
     return MqttConf(
-        broker="localhost",
+        host="localhost",
         port=1883,
         user="user",
         password="passwd",  # noqa: S106, this is a test password
@@ -46,7 +46,7 @@ def test_mqtt_base_intialization(mock_mqtt_client, mock_mqtt_conf):
     mock_mqtt_client.return_value.loop_start.assert_called_once()
     mock_client_instance = mock_mqtt_client.return_value
     mock_client_instance.username_pw_set.assert_called_with(mock_mqtt_conf.user, mock_mqtt_conf.password)
-    mock_client_instance.connect.assert_called_with(mock_mqtt_conf.broker, mock_mqtt_conf.port)
+    mock_client_instance.connect.assert_called_with(mock_mqtt_conf.host, mock_mqtt_conf.port)
     assert base.client
     assert base.client.on_connect == base._on_connect
     assert base.client.on_disconnect == base._on_disconnect
@@ -58,7 +58,7 @@ def test_mqtt_base_on_connect(mock_mqtt_client, mock_mqtt_conf, capsys):
     base = MqttBase(config=mock_mqtt_conf)
     base._on_connect(None, None, {}, 0)
     captured = capsys.readouterr()
-    assert f"MQTT node connected to {mock_mqtt_conf.broker}:{mock_mqtt_conf.port}" in captured.out
+    assert f"MQTT node connected to {mock_mqtt_conf.host}:{mock_mqtt_conf.port}" in captured.out
 
 
 def test_mqtt_base_on_disconnect_with_error(mock_mqtt_client, mock_mqtt_conf, capsys):

--- a/tests/test_mqtt.py
+++ b/tests/test_mqtt.py
@@ -40,12 +40,14 @@ def mock_queue():
 def test_mqtt_base_intialization(mock_mqtt_client, mock_mqtt_conf):
     """Test that the intialization of the mqtt client is as expected."""
     base = MqttBase(config=mock_mqtt_conf)
+    base.start()
 
     mock_mqtt_client.assert_called_once()
     mock_mqtt_client.return_value.loop_start.assert_called_once()
     mock_client_instance = mock_mqtt_client.return_value
     mock_client_instance.username_pw_set.assert_called_with(mock_mqtt_conf.user, mock_mqtt_conf.password)
     mock_client_instance.connect.assert_called_with(mock_mqtt_conf.broker, mock_mqtt_conf.port)
+    assert base.client
     assert base.client.on_connect == base._on_connect
     assert base.client.on_disconnect == base._on_disconnect
     assert base.client.on_publish == base._on_publish
@@ -71,7 +73,8 @@ def test_mqtt_base_on_disconnect_with_error(mock_mqtt_client, mock_mqtt_conf, ca
 
 def test_mqtt_subscribes_single_topic(mock_mqtt_client, mock_mqtt_conf):
     """Test that the mqtt client subscribes to a single topic."""
-    _ = MqttSubscriber(topics="singleTopic", config=mock_mqtt_conf)
+    sub = MqttSubscriber(topics="singleTopic", config=mock_mqtt_conf)
+    sub.start()
 
     actual_calls = mock_mqtt_client.return_value.subscribe.call_args_list
     assert actual_calls == [call("singleTopic", mock_mqtt_conf.qos)]
@@ -82,7 +85,8 @@ def test_mqtt_subscribes_multiple_topics(mock_mqtt_client, mock_mqtt_conf):
 
     I would love to do this via parametrization, but the call argument is built differently for single size lists and longer lists.
     """
-    _ = MqttSubscriber(topics=["multiple1", "multiple2"], config=mock_mqtt_conf)
+    sub = MqttSubscriber(topics=["multiple1", "multiple2"], config=mock_mqtt_conf)
+    sub.start()
 
     actual_calls = mock_mqtt_client.return_value.subscribe.call_args_list
     assert actual_calls == [
@@ -92,7 +96,8 @@ def test_mqtt_subscribes_multiple_topics(mock_mqtt_client, mock_mqtt_conf):
 
 def test_mqtt_subscribes_multiple_topics_tuple(mock_mqtt_client, mock_mqtt_conf):
     """Test that the mqtt client subscribes to multiple topics passed as tuple."""
-    _ = MqttSubscriber(topics=("multiple1", "multiple2"), config=mock_mqtt_conf)
+    sub = MqttSubscriber(topics=("multiple1", "multiple2"), config=mock_mqtt_conf)
+    sub.start()
 
     actual_calls = mock_mqtt_client.return_value.subscribe.call_args_list
     assert actual_calls == [

--- a/tests/test_serial.py
+++ b/tests/test_serial.py
@@ -93,7 +93,7 @@ def test_serial_publisher_initialization(mock_serial_device_publisher, serial_co
         parity=serial.PARITY_NONE,
         stopbits=serial.STOPBITS_ONE,
     )
-    assert publisher.serial
+    assert publisher.serial_connection
 
 
 def test_serial_publisher_send(mock_serial_device_publisher, serial_conf):

--- a/tests/test_serial.py
+++ b/tests/test_serial.py
@@ -29,10 +29,11 @@ def mock_serial_device_publisher():
 def test_serial_subscriber_initialization(mock_serial_device_subscriber, serial_conf):
     """Test that the SerialSubscriber class initializes correctly.
     Mocks the serial.Serial class to avoid opening a serial port."""
-    _ = SerialSubscriber(
+    sub = SerialSubscriber(
         config=serial_conf,
         topic="",
     )
+    sub.start()
     mock_serial_device_subscriber.assert_called_with(
         port=serial_conf.port,
         baudrate=serial_conf.baudrate,
@@ -45,6 +46,7 @@ def test_serial_subscriber_initialization(mock_serial_device_subscriber, serial_
 def test_serial_subscriber_receive(mock_serial_device_subscriber, serial_conf):
     """Test that the SerialSubscriber class calls readline and unpack as expected."""
     subscriber = SerialSubscriber(config=serial_conf, topic="")
+    subscriber.start()
 
     # Set up the readline return value
     mock_serial_instance = mock_serial_device_subscriber.return_value
@@ -69,6 +71,7 @@ def test_serial_subscriber_converts_bytes_to_str():
     """Test that the SerialSubscriber class converts bytes to str as expected."""
     with patch("heisskleber.serial.subscriber.serial.Serial") as mock_serial:
         subscriber = SerialSubscriber(config=SerialConf(), topic="", custom_unpack=lambda x: x)
+        subscriber.start()
 
         # Set the readline method to raise UnicodeError
         mock_serial_instance = mock_serial.return_value
@@ -86,6 +89,7 @@ def test_serial_publisher_initialization(mock_serial_device_publisher, serial_co
     """Test that the SerialPublisher class initializes correctly.
     Mocks the serial.Serial class to avoid opening a serial port."""
     publisher = SerialPublisher(config=serial_conf)
+    publisher.start()
     mock_serial_device_publisher.assert_called_with(
         port=serial_conf.port,
         baudrate=serial_conf.baudrate,

--- a/tests/test_streamer.py
+++ b/tests/test_streamer.py
@@ -67,11 +67,12 @@ async def test_resampler_multiple_modes(mock_subscriber):
         ]
     )
 
-    config = ResamplerConf(resample_rate=1000)  # Fill in your MQTT configuration
+    config = ResamplerConf(resample_rate=1000)
     resampler = Resampler(config, mock_subscriber)
 
     # Test the resample method
     resampled_data = [await resampler.receive() for _ in range(3)]
+    resampler.stop()
 
     assert resampled_data[0] == {"epoch": 0.0, "data": 1.5}
     assert resampled_data[1] == {"epoch": 1.0, "data": 3.5}
@@ -89,11 +90,12 @@ async def test_resampler_upsampling(mock_subscriber):
         ]
     )
 
-    config = ResamplerConf(resample_rate=250)  # Fill in your MQTT configuration
+    config = ResamplerConf(resample_rate=250)
     resampler = Resampler(config, mock_subscriber)
 
     # Test the resample method
     resampled_data = [await resampler.receive() for _ in range(7)]
+    resampler.stop()
 
     assert resampled_data[0] == {"epoch": 0.0, "data": 1.0}
     assert resampled_data[1] == {"epoch": 0.25, "data": 1.25}

--- a/tests/test_zmq.py
+++ b/tests/test_zmq.py
@@ -59,7 +59,9 @@ def test_send_receive(start_broker):
     print("test_send_receive")
     topic = "test"
     source = get_source("zmq", topic)
+    source.start()
     sink = get_sink("zmq")
+    sink.start()
     time.sleep(1)  # this is crucial, otherwise the source might hang
     for i in range(10):
         message = {"m": i}

--- a/tests/test_zmq.py
+++ b/tests/test_zmq.py
@@ -33,9 +33,9 @@ def start_broker():
 
 
 def test_config_parses_correctly():
-    conf = ZmqConf(protocol="tcp", interface="localhost", publisher_port=5555, subscriber_port=5556)
+    conf = ZmqConf(protocol="tcp", host="localhost", publisher_port=5555, subscriber_port=5556)
     assert conf.protocol == "tcp"
-    assert conf.interface == "localhost"
+    assert conf.host == "localhost"
     assert conf.publisher_port == 5555
     assert conf.subscriber_port == 5556
 
@@ -44,13 +44,13 @@ def test_config_parses_correctly():
 
 
 def test_instantiate_subscriber():
-    conf = ZmqConf(protocol="tcp", interface="localhost", publisher_port=5555, subscriber_port=5556)
+    conf = ZmqConf(protocol="tcp", host="localhost", publisher_port=5555, subscriber_port=5556)
     sub = ZmqSubscriber(conf, "test")
     assert sub.config == conf
 
 
 def test_instantiate_publisher():
-    conf = ZmqConf(protocol="tcp", interface="localhost", publisher_port=5555, subscriber_port=5556)
+    conf = ZmqConf(protocol="tcp", host="localhost", publisher_port=5555, subscriber_port=5556)
     pub = ZmqPublisher(conf)
     assert pub.config == conf
 

--- a/tests/zmq/test_zmq_asyncio.py
+++ b/tests/zmq/test_zmq_asyncio.py
@@ -51,6 +51,8 @@ async def test_send_receive(start_broker) -> None:
     conf = ZmqConf(protocol="tcp", interface="localhost", publisher_port=5555, subscriber_port=5556)
     source = ZmqAsyncSubscriber(conf, topic)
     sink = ZmqAsyncPublisher(conf)
+    source.start()
+    sink.start()
     time.sleep(1)  # this is crucial, otherwise the source might hang
     for i in range(10):
         message = {"m": i}

--- a/tests/zmq/test_zmq_asyncio.py
+++ b/tests/zmq/test_zmq_asyncio.py
@@ -33,13 +33,13 @@ def start_broker() -> Generator[Process, None, None]:
 
 
 def test_instantiate_subscriber() -> None:
-    conf = ZmqConf(protocol="tcp", interface="localhost", publisher_port=5555, subscriber_port=5556)
+    conf = ZmqConf(protocol="tcp", host="localhost", publisher_port=5555, subscriber_port=5556)
     sub = ZmqAsyncSubscriber(conf, "test")
     assert sub.config == conf
 
 
 def test_instantiate_publisher() -> None:
-    conf = ZmqConf(protocol="tcp", interface="localhost", publisher_port=5555, subscriber_port=5556)
+    conf = ZmqConf(protocol="tcp", host="localhost", publisher_port=5555, subscriber_port=5556)
     pub = ZmqPublisher(conf)
     assert pub.config == conf
 
@@ -48,7 +48,7 @@ def test_instantiate_publisher() -> None:
 async def test_send_receive(start_broker) -> None:
     print("test_send_receive")
     topic = "test"
-    conf = ZmqConf(protocol="tcp", interface="localhost", publisher_port=5555, subscriber_port=5556)
+    conf = ZmqConf(protocol="tcp", host="localhost", publisher_port=5555, subscriber_port=5556)
     source = ZmqAsyncSubscriber(conf, topic)
     sink = ZmqAsyncPublisher(conf)
     source.start()


### PR DESCRIPTION
No longer implicitly starting threads and tasks when instantiating objects. Instead, start() and stop() functions are added to the source and sink baseclasses to ensure more fine control over behaviour and lifetime of background loops. 

To maintain backwards compability and ease of use, start() is lazily run when invoking send() or receive() function, respectively.

Should be end to end tested before merging.