### PR TITLE
Fix default is_connected value of async zmq subscriber.

### DIFF
--- a/heisskleber/__init__.py
+++ b/heisskleber/__init__.py
@@ -16,4 +16,4 @@ __all__ = [
     "AsyncSink",
     "AsyncSource",
 ]
-__version__ = "0.5.3"
+__version__ = "0.5.4"

--- a/heisskleber/core/async_factories.py
+++ b/heisskleber/core/async_factories.py
@@ -1,5 +1,6 @@
 from heisskleber.config import BaseConf, load_config
 from heisskleber.mqtt import AsyncMqttPublisher, AsyncMqttSubscriber, MqttConf
+from heisskleber.udp import AsyncUdpSink, AsyncUdpSource, UdpConf
 from heisskleber.zmq import ZmqAsyncPublisher, ZmqAsyncSubscriber, ZmqConf
 
 from .types import AsyncSink, AsyncSource
@@ -7,11 +8,13 @@ from .types import AsyncSink, AsyncSource
 _registered_async_sinks: dict[str, tuple[type[AsyncSink], type[BaseConf]]] = {
     "mqtt": (AsyncMqttPublisher, MqttConf),
     "zmq": (ZmqAsyncPublisher, ZmqConf),
+    "udp": (AsyncUdpSink, UdpConf),
 }
 
 _registered_async_sources: dict[str, tuple] = {
     "mqtt": (AsyncMqttSubscriber, MqttConf),
     "zmq": (ZmqAsyncSubscriber, ZmqConf),
+    "udp": (AsyncUdpSource, UdpConf),
 }
 
 

--- a/heisskleber/run/cli.py
+++ b/heisskleber/run/cli.py
@@ -79,7 +79,7 @@ def main() -> None:
     elif isinstance(source, ZmqSubscriber):
         source.config.host = args.host or source.config.host
         source.config.subscriber_port = args.port or source.config.subscriber_port
-        args.topic = "" if args.topic == "#" else args.topic
+        source.topic = "" if args.topic == "#" else args.topic
     elif isinstance(source, UdpSubscriber):
         source.config.port = args.port or source.config.port
 

--- a/heisskleber/zmq/subscriber.py
+++ b/heisskleber/zmq/subscriber.py
@@ -130,7 +130,7 @@ class ZmqAsyncSubscriber(AsyncSource):
         self.context = zmq.asyncio.Context.instance()
         self.socket: zmq.asyncio.Socket = self.context.socket(zmq.SUB)
         self.unpack = get_unpacker(config.packstyle)
-        self.is_connected = True
+        self.is_connected = False
 
     async def receive(self) -> tuple[str, dict]:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "heisskleber"
-version = "0.5.3"
+version = "0.5.4"
 description = "Heisskleber"
 authors = ["Felix Weiler <felix@flucto.tech>"]
 license = "MIT"


### PR DESCRIPTION
Hot fix for bug occuring when ZmqSubscriberAsync.receive() was called without starting the background loop first. 
The assumption that start() would be called implicitly was not fulfilled, as the field is_connected, was set to True by default.