### PR TITLE
Add source_id to MqttConf

### DIFF
--- a/config/heisskleber/mqtt.yaml
+++ b/config/heisskleber/mqtt.yaml
@@ -1,9 +1,16 @@
-host: "10.47.36.1"
-user: ""
-password: ""
+# Heisskleber config file for MqttConf
+host: localhost
+mapping: /deprecated/
+max_saved_messages: 100
+packstyle: json
+password: ''
 port: 1883
-ssl: False
+print_stdout: false
 qos: 0
-topics: ["test"]
-mapping: ""
-packstyle: "json"
+retain: false
+source_id: box-01
+ssl: false
+timeout_s: 60
+topics: []
+user: ''
+verbose: false

--- a/config/heisskleber/serial.yaml
+++ b/config/heisskleber/serial.yaml
@@ -1,6 +1,7 @@
-verbose: false
-port: "/dev/ttyUSB0"
-baudrate: 19200
+# Heisskleber config file for SerialConf
+baudrate: 9600
 bytesize: 8
-encoding: "utf-8"
-packstyle: "serial" # not yet implemented
+encoding: ascii
+port: /dev/serial0
+print_stdout: false
+verbose: false

--- a/config/heisskleber/tcp.yaml
+++ b/config/heisskleber/tcp.yaml
@@ -1,0 +1,6 @@
+# Heisskleber config file for TcpConf
+host: localhost
+port: 6000
+print_stdout: false
+timeout: 60
+verbose: false

--- a/config/heisskleber/udp.yaml
+++ b/config/heisskleber/udp.yaml
@@ -1,0 +1,9 @@
+# Heisskleber config file for UdpConf
+delimiter: "\r\n"
+encoding: utf-8
+host: 127.0.0.1
+max_queue_size: 1000
+packer: json
+port: 1234
+print_stdout: false
+verbose: false

--- a/config/heisskleber/zmq.yaml
+++ b/config/heisskleber/zmq.yaml
@@ -1,4 +1,8 @@
-protocol: "tcp" # ipc protocol
-host: "127.0.0.1" # the interface to bind to
-publisher_port: 5555 # port used by primary producers
-subscriber_port: 5556 # port used by primary consumers
+# Heisskleber config file for ZmqConf
+host: 127.0.0.1
+packstyle: json
+print_stdout: false
+protocol: tcp
+publisher_port: 5555
+subscriber_port: 5556
+verbose: false

--- a/heisskleber/__init__.py
+++ b/heisskleber/__init__.py
@@ -16,4 +16,4 @@ __all__ = [
     "AsyncSink",
     "AsyncSource",
 ]
-__version__ = "0.5.6"
+__version__ = "0.5.7"

--- a/heisskleber/mqtt/config.py
+++ b/heisskleber/mqtt/config.py
@@ -17,7 +17,8 @@ class MqttConf(BaseConf):
     qos: int = 0
     retain: bool = False
     topics: list[str] = field(default_factory=list)
-    mapping: str = "/msb/"
+    mapping: str = "/deprecated/"  # deprecated
     packstyle: str = "json"
     max_saved_messages: int = 100
     timeout_s: int = 60
+    source_id: str = "box-01"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "heisskleber"
-version = "0.5.6"
+version = "0.5.7"
 description = "Heisskleber"
 authors = ["Felix Weiler <felix@flucto.tech>"]
 license = "MIT"

--- a/run/export_configs.py
+++ b/run/export_configs.py
@@ -1,0 +1,17 @@
+from dataclasses import asdict
+
+import yaml
+
+from heisskleber.mqtt.config import MqttConf
+from heisskleber.serial.config import SerialConf
+from heisskleber.tcp.config import TcpConf
+from heisskleber.udp.config import UdpConf
+from heisskleber.zmq.config import ZmqConf
+
+configs = {"mqtt": MqttConf(), "zmq": ZmqConf(), "udp": UdpConf(), "tcp": TcpConf(), "serial": SerialConf()}
+
+
+for name, config in configs.items():
+    with open(f"./config/heisskleber/{name}.yaml", "w") as file:
+        file.write(f"# Heisskleber config file for {config.__class__.__name__}\n")
+        file.write(yaml.dump(asdict(config)))


### PR DESCRIPTION
This PR suggests a change to MqttConf, aligning with the internal decision to change the way the source id is handled. 

mapping is deprecated, but still available.

Added a script to generate .yaml files from Conf dataclasses.