### PR TITLE
Turn sources into iterators

### DIFF
--- a/heisskleber/core/types.py
+++ b/heisskleber/core/types.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Union
 
 from heisskleber.config import BaseConf
 
-Serializable = Union[str, int, float]
+Serializable = Union[int, float]
 
 
 class Sink(ABC):

--- a/heisskleber/core/types.py
+++ b/heisskleber/core/types.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import AsyncGenerator, Generator
 from typing import Any, Callable, Union
 
 from heisskleber.config import BaseConf
@@ -55,6 +56,10 @@ class Source(ABC):
 
     unpack: Callable[[str], dict[str, Serializable]]
 
+    def __iter__(self) -> Generator[tuple[str, dict[str, Serializable]], None, None]:
+        topic, data = self.receive()
+        yield topic, data
+
     @abstractmethod
     def __init__(self, config: BaseConf, topic: str | list[str]) -> None:
         """
@@ -94,6 +99,11 @@ class AsyncSource(ABC):
     """
     AsyncSubscriber interface
     """
+
+    async def __aiter__(self) -> AsyncGenerator[tuple[str, dict[str, Serializable]], None]:
+        while True:
+            topic, data = await self.receive()
+            yield topic, data
 
     @abstractmethod
     def __init__(self, config: Any, topic: str | list[str]) -> None:


### PR DESCRIPTION
This PR adds __iter__ to the Source baseclass and __aiter__ to the AsyncSource baseclass. The function is already implemented and does not need to be overridden, as it simply calls self.receive() and yields the result.

Also modifies the Serializable type to be `int | float`, removing the pesky `str` from the definition. Should be redone properly in a future iteration.