### PR TITLE
Switch to pathlib for config paths.

### DIFF
--- a/heisskleber/config/__init__.py
+++ b/heisskleber/config/__init__.py
@@ -1,4 +1,4 @@
-from .config import BaseConf
-from .parse import ConfigType, load_config
+from .config import BaseConf, Config
+from .parse import load_config
 
-__all__ = ["load_config", "BaseConf", "ConfigType"]
+__all__ = ["load_config", "BaseConf", "Config"]

--- a/heisskleber/config/config.py
+++ b/heisskleber/config/config.py
@@ -1,7 +1,7 @@
 import socket
 import warnings
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, TypeVar
 
 
 @dataclass
@@ -28,3 +28,8 @@ class BaseConf:
     @property
     def serial_number(self) -> str:
         return socket.gethostname().upper()
+
+
+Config = TypeVar(
+    "Config", bound=BaseConf
+)  # https://stackoverflow.com/a/46227137 , https://docs.python.org/3/library/typing.html#typing.TypeVar

--- a/heisskleber/config/parse.py
+++ b/heisskleber/config/parse.py
@@ -1,50 +1,47 @@
-import os
-import warnings
-from typing import TypeVar
+import logging
+from pathlib import Path
+from typing import Any
 
 import yaml
 
-from heisskleber.config import BaseConf
 from heisskleber.config.cmdline import get_cmdline
+from heisskleber.config.config import Config
 
-ConfigType = TypeVar(
-    "ConfigType", bound=BaseConf
-)  # https://stackoverflow.com/a/46227137 , https://docs.python.org/3/library/typing.html#typing.TypeVar
+log = logging.getLogger(__name__)
 
 
-def get_config_dir() -> str:
-    config_dir = os.path.join(os.path.join(os.environ["HOME"], ".config"), "heisskleber")
-    if not os.path.isdir(config_dir):
-        warnings.warn(f"no such directory: {config_dir}", stacklevel=2)
+def get_config_dir() -> Path:
+    config_dir = Path.home() / ".config" / "heisskleber"
+    if not config_dir.is_dir():
+        log.error(f"no such directory: {config_dir}", stacklevel=2)
         raise FileNotFoundError
     return config_dir
 
 
-def get_config_filepath(filename: str) -> str:
-    config_filepath = os.path.join(get_config_dir(), filename)
-    if not os.path.isfile(config_filepath):
-        warnings.warn(f"no such file: {config_filepath}", stacklevel=2)
+def get_config_filepath(filename: str) -> Path:
+    config_filepath = get_config_dir() / filename
+    if not config_filepath.is_file():
+        log.error(f"no such file: {config_filepath}", stacklevel=2)
         raise FileNotFoundError
     return config_filepath
 
 
-def read_yaml_config_file(config_fpath: str) -> dict:
-    with open(config_fpath) as config_filehandle:
-        return yaml.safe_load(config_filehandle)
+def read_yaml_config_file(config_fpath: Path) -> dict[str, Any]:
+    with config_fpath.open() as config_filehandle:
+        return yaml.safe_load(config_filehandle)  # type: ignore [no-any-return]
 
 
-def update_config(config: ConfigType, config_dict: dict) -> ConfigType:
+def update_config(config: Config, config_dict: dict[str, Any]) -> Config:
     for config_key, config_value in config_dict.items():
-        # get expected type of element from config_object:
         if not hasattr(config, config_key):
             error_msg = f"no such configuration parameter: {config_key}, skipping"
-            warnings.warn(error_msg, stacklevel=2)
+            log.info(error_msg, stacklevel=2)
             continue
         cast_func = type(config[config_key])
         try:
             config[config_key] = cast_func(config_value)
         except Exception as e:
-            warnings.warn(
+            log.warning(
                 f"failed to cast {config_value} to {type(config[config_key])}: {e}. skipping",
                 stacklevel=2,
             )
@@ -52,7 +49,7 @@ def update_config(config: ConfigType, config_dict: dict) -> ConfigType:
     return config
 
 
-def load_config(config: ConfigType, config_filename: str, read_commandline: bool = True) -> ConfigType:
+def load_config(config: Config, config_filename: str, read_commandline: bool = True) -> Config:
     """Load the config file and update the config object.
 
     Parameters

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,9 +1,12 @@
-import os
 import unittest.mock as mock
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from heisskleber.config import BaseConf
+from heisskleber.config.config import Config
 from heisskleber.config.parse import (
     get_cmdline,
     get_config_dir,
@@ -14,41 +17,83 @@ from heisskleber.config.parse import (
 )
 
 
-def test_get_config_dir():
-    with mock.patch("os.path.isdir", return_value=True):
-        assert get_config_dir() == os.path.join(os.path.join(os.environ["HOME"], ".config"), "heisskleber")
+@pytest.fixture
+def mock_home(monkeypatch):
+    home = Path("/mock/home")
+    monkeypatch.setattr(Path, "home", lambda: home)
+    return home
 
 
-def test_get_config_filepath():
-    with mock.patch("os.path.isfile", return_value=True), mock.patch("os.path.isdir", return_value=True):
-        assert get_config_filepath("test_config.yaml") == os.path.join(
-            os.path.join(os.environ["HOME"], ".config"),
-            "heisskleber",
-            "test_config.yaml",
-        )
+@pytest.fixture
+def mock_config_dir(mock_home):
+    with (
+        patch("heisskleber.config.parse.get_config_dir", return_value=mock_home / ".config" / "heisskleber"),
+        patch("pathlib.Path.is_dir", return_value=True),
+    ):
+        yield
 
 
-@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_get_config_dir(mock_home):
+    with patch("pathlib.Path.is_dir", return_value=True):
+        config_dir = get_config_dir()
+    assert config_dir == mock_home / ".config" / "heisskleber"
+
+
+def test_get_config_dir_not_exists():
+    with patch("pathlib.Path.is_dir", return_value=False), pytest.raises(FileNotFoundError):
+        get_config_dir()
+
+
+def test_get_config_filepath(mock_home, mock_config_dir):
+    filename = "config.yaml"
+    expected_path = mock_home / ".config" / "heisskleber" / filename
+
+    with patch("pathlib.Path.is_file", return_value=True):
+        config_filepath = get_config_filepath(filename)
+
+    assert config_filepath == expected_path
+
+
+def test_update_config():
+    @dataclass
+    class MockConf(BaseConf):
+        existing_key: str = "old"
+
+    config = MockConf(existing_key="old_value")
+    config_dict = {"existing_key": "new_value", "non_existing_key": "value"}
+
+    updated_config = update_config(config, config_dict)
+
+    assert updated_config.existing_key == "new_value"
+
+
+def test_load_config_no_cmdline(mock_home):
+    config = MagicMock(spec=Config)
+    config_dict = {"key": "value"}
+    filename = "config"
+    filepath = mock_home / ".config" / "heisskleber" / (filename + ".yaml")
+
+    with (
+        patch("heisskleber.config.parse.get_config_dir", return_value=mock_home / ".config" / "heisskleber"),
+        patch("heisskleber.config.parse.get_config_filepath", return_value=filepath),
+        patch("heisskleber.config.parse.read_yaml_config_file", return_value=config_dict),
+        patch("heisskleber.config.parse.update_config", return_value=config) as mock_update_config,
+    ):
+        result = load_config(config, filename, read_commandline=False)
+
+    mock_update_config.assert_called_with(config, config_dict)
+    assert result == config
+
+
 def test_file_exists():
     with pytest.raises(FileNotFoundError):
         get_config_filepath("i_do_not_exist.yaml")
 
 
 def test_read_yaml_config_file():
-    config_dict = read_yaml_config_file("tests/config.yaml")
+    config_dict = read_yaml_config_file(Path("tests/config.yaml"))
     assert config_dict["verbose"] is True
     assert config_dict["print_stdout"] is False
-
-
-def test_update_config():
-    conf_obj = BaseConf()
-    conf_obj["verbose"] = False
-    conf_obj["print_stdout"] = False
-    conf_dict = {"verbose": True, "print_stdout": True}
-    conf_obj = update_config(conf_obj, conf_dict)
-
-    assert conf_obj.verbose is True
-    assert conf_obj.print_stdout is True
 
 
 def test_get_cmdline_patch_argv():
@@ -68,13 +113,13 @@ def test_get_cmdline():
 
 
 def test_load_config_from_file():
-    with mock.patch("heisskleber.config.parse.get_config_filepath", return_value="tests/config.yaml"):
+    with mock.patch("heisskleber.config.parse.get_config_filepath", return_value=Path("tests/config.yaml")):
         conf = load_config(BaseConf(), "config", read_commandline=False)
         assert conf.verbose is True
 
 
-def test_load_config():
-    with mock.patch("heisskleber.config.parse.get_config_filepath", return_value="tests/config.yaml"), mock.patch(
+def test_load_config_from_yaml():
+    with mock.patch("heisskleber.config.parse.get_config_filepath", return_value=Path("tests/config.yaml")), mock.patch(
         "sys.argv", ["test.py", "--print-stdout"]
     ):
         conf = load_config(BaseConf(), "config")


### PR DESCRIPTION
For our dear Windows users and for the sake of dispatching the old ways and `os.path`, switching to pathlib was overdue. This PR refactors some functions in `config/parse.py` to use pathlib. 