### PR TITLE
Fix #183, MqttSender now correctly raises PackerError.

### DIFF
--- a/tests/mqtt/test_mqtt_sink.py
+++ b/tests/mqtt/test_mqtt_sink.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+from heisskleber.core import PackerError
 from heisskleber.mqtt import MqttConf, MqttSender
 
 
@@ -26,5 +27,27 @@ async def test_send_work_successful_publish() -> None:
         await asyncio.sleep(0.1)
 
         mock_client.publish.assert_awaited_once_with(topic=test_topic, payload=mock_packer.return_value)
+
+        await sink.stop()
+
+
+@pytest.mark.asyncio
+async def test_mqtt_send_raises_error() -> None:
+    class ErrorPacker:
+        def __call__(self, data: str) -> bytes:
+            raise PackerError(data)
+
+    mqtt_config = MqttConf()
+    sink = MqttSender(config=mqtt_config, packer=ErrorPacker())
+    test_data = "test"
+    test_topic = "test/topic"
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock()
+
+    with patch("aiomqtt.Client", return_value=mock_client):
+        with pytest.raises(PackerError):
+            await sink.send(test_data, test_topic)
 
         await sink.stop()


### PR DESCRIPTION
Small fix for MqttSender to close #183. Previously, the packer function was called in the background task, silently failing upon a PackerError. 

The packer function was moved to the send function, so that it will immediately raise a PackerError when the data cannot be serialized. The user may then decide what to do with that error.