### PR TITLE
Correctly check literal values in configuration.

### DIFF
--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1,8 +1,11 @@
+import logging
 from dataclasses import dataclass
+from typing import Literal
 
 import pytest
 
 from heisskleber.core import BaseConf
+from heisskleber.core.config import _check_type
 
 
 @dataclass
@@ -53,3 +56,29 @@ def test_conf_from_file() -> None:
     assert test_conf.name == "Frodo"
     assert test_conf.age == 30
     assert test_conf.speed == 0.5
+
+
+@dataclass
+class ConfigWithLiteral(BaseConf):
+    direction: Literal["U", "D"] = "U"
+
+
+def test_parses_literal() -> None:
+    test_dict = {"direction": "U"}
+    expected = ConfigWithLiteral(direction="U")
+
+    config = ConfigWithLiteral.from_dict(test_dict)
+
+    assert config == expected
+
+
+def test_logs_literal_error(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.ERROR)
+
+    expected = Literal[1, 2, 3]
+
+    with pytest.raises(TypeError):
+        _check_type(4, expected)
+
+    assert len(caplog.records) == 1
+    assert "4 is not part of (1, 2, 3)" in caplog.text

--- a/tests/serial/test_serial_config.py
+++ b/tests/serial/test_serial_config.py
@@ -1,0 +1,9 @@
+from heisskleber.serial import SerialConf
+
+
+def test_serial_config() -> None:
+    config_dict = {"port": "/test/serial", "baudrate": 5000, "parity": "N", "stopbits": 1}
+
+    config = SerialConf.from_dict(config_dict)
+
+    assert config == SerialConf(port="/test/serial", baudrate=5000, parity="N", stopbits=1)


### PR DESCRIPTION
Fixes #204, which exposed a general bug when subclasses of BaseConf define a field as type Literal.

Literal types are now correctly checked and a type error raised, when the assigned value does not comply with the literal definition.