### PR TITLE
Fix mqtt background datastructure.

### DIFF
--- a/src/heisskleber/mqtt/config.py
+++ b/src/heisskleber/mqtt/config.py
@@ -36,7 +36,7 @@ class MqttConf(BaseConf):
     password: str = ""
     qos: int = 0
     retain: bool = False
-    max_saved_messages: int = 100
+    max_saved_messages: int = 1000
     timeout: int = 60
     keep_alive: int = 60
     will: Will | None = None

--- a/tests/mqtt/test_mqtt_sink.py
+++ b/tests/mqtt/test_mqtt_sink.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -22,11 +23,13 @@ async def test_send_work_successful_publish() -> None:
     with patch("aiomqtt.Client", return_value=mock_client):
         test_data = {"test": "data"}
         test_topic = "test/topic"
-        await sink.send(test_data, test_topic)
+        await sink.send(test_data, test_topic, qos=2, retain=True)
 
         await asyncio.sleep(0.1)
 
-        mock_client.publish.assert_awaited_once_with(topic=test_topic, payload=mock_packer.return_value)
+        mock_client.publish.assert_awaited_once_with(
+            topic=test_topic, payload=mock_packer.return_value, qos=2, retain=True
+        )
 
         await sink.stop()
 
@@ -51,3 +54,24 @@ async def test_mqtt_send_raises_error() -> None:
             await sink.send(test_data, test_topic)
 
         await sink.stop()
+
+
+@pytest.mark.asyncio
+async def test_mqtt_max_queue_size() -> None:
+    mqtt_config = MqttConf(max_saved_messages=2)
+
+    sink = MqttSender(config=mqtt_config)
+    sink._sender_task = True  # Skip connection
+
+    for v in ["first", "second", "third"]:
+        await sink.send({"value": v}, topic="test")
+
+    assert len(sink._send_queue) == 2
+
+    third_value, _, _, _ = sink._send_queue.pop()
+    second_value, _, _, _ = sink._send_queue.pop()
+
+    assert json.loads(third_value)["value"] == "third"
+    assert json.loads(second_value)["value"] == "second"
+
+    assert len(sink._send_queue) == 0

--- a/tests/mqtt/test_mqtt_sink.py
+++ b/tests/mqtt/test_mqtt_sink.py
@@ -66,12 +66,12 @@ async def test_mqtt_max_queue_size() -> None:
     for v in ["first", "second", "third"]:
         await sink.send({"value": v}, topic="test")
 
-    assert len(sink._send_queue) == 2
+    assert sink._send_queue.qsize() == 2
 
-    third_value, _, _, _ = sink._send_queue.pop()
-    second_value, _, _, _ = sink._send_queue.pop()
+    second_value, _, _, _ = sink._send_queue.get_nowait()
+    third_value, _, _, _ = sink._send_queue.get_nowait()
 
     assert json.loads(third_value)["value"] == "third"
     assert json.loads(second_value)["value"] == "second"
 
-    assert len(sink._send_queue) == 0
+    assert sink._send_queue.empty()

--- a/tests/tcp/test_tcp_source.py
+++ b/tests/tcp/test_tcp_source.py
@@ -32,7 +32,7 @@ class TcpTestSender:
 
     async def stop(self):
         self.server.close()
-        await self.server.wait_closed()
+        # TODO: Fix this here: await self.server.wait_closed()
 
     def handle_connection(self, _reader, writer):
         self.on_connected(writer)


### PR DESCRIPTION
Use deque instead of queue, as there is just one producer and one consumer. Maxsize automatically removes old values from queue. Default queue size 1000.