### PR TITLE
Fixed config and sender in order for the UWB-Module integration

### DIFF
--- a/src/heisskleber/serial/config.py
+++ b/src/heisskleber/serial/config.py
@@ -26,4 +26,4 @@ class SerialConf(BaseConf):
     bytesize: int = 8
     encoding: str = "ascii"
     parity: Literal["N", "O", "E"] = "N"  # definitions from serial.PARTITY_'N'ONE / 'O'DD / 'E'VEN
-    stopbits: Literal[1, 2] = 1 # 1.5 not yet implemented
+    stopbits: Literal[1, 2] = 1  # 1.5 not yet implemented

--- a/src/heisskleber/serial/config.py
+++ b/src/heisskleber/serial/config.py
@@ -25,5 +25,5 @@ class SerialConf(BaseConf):
     baudrate: int = 9600
     bytesize: int = 8
     encoding: str = "ascii"
-    parity: str = "N"  # definitions from serial.PARTITY_'N'ONE / 'O'DD / 'E'VEN
-    stopbits: int = 1  # 1.5 not yet implemented
+    parity: Literal["N", "O", "E"] = "N"  # definitions from serial.PARTITY_'N'ONE / 'O'DD / 'E'VEN
+    stopbits: Literal[1, 2] = 1 # 1.5 not yet implemented

--- a/src/heisskleber/serial/config.py
+++ b/src/heisskleber/serial/config.py
@@ -25,5 +25,5 @@ class SerialConf(BaseConf):
     baudrate: int = 9600
     bytesize: int = 8
     encoding: str = "ascii"
-    parity: Literal["N", "O", "E"] = "N"  # definitions from serial.PARTITY_'N'ONE / 'O'DD / 'E'VEN
-    stopbits: Literal[1, 2] = 1  # 1.5 not yet implemented
+    parity: str = "N"  # definitions from serial.PARTITY_'N'ONE / 'O'DD / 'E'VEN
+    stopbits: int = 1  # 1.5 not yet implemented

--- a/src/heisskleber/serial/sender.py
+++ b/src/heisskleber/serial/sender.py
@@ -83,6 +83,8 @@ class SerialSender(Sender[T]):
             stopbits=self.config.stopbits,
         )
 
+        self._is_connected = True
+
     async def stop(self) -> None:
         """Close serial connection."""
         self._ser.close()


### PR DESCRIPTION
These changes were necessary in order to allow for a successful serial connection to the UWB-sensors. 