### PR TITLE
added ConsoleConf to top level __init__.py

### DIFF
--- a/src/heisskleber/__init__.py
+++ b/src/heisskleber/__init__.py
@@ -11,9 +11,9 @@ from heisskleber.zmq import ZmqConf, ZmqReceiver, ZmqSender
 
 __all__ = [
     # console
+    "ConsoleConf",
     "ConsoleReceiver",
     "ConsoleSender",
-    "ConsoleConf",
     # file
     "FileConf",
     "FileReader",


### PR DESCRIPTION
convenience fix: added `ConsoleConf` to the top level __init__.py 