### PR TITLE
Implement REST / HTTP sources and sinks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,10 @@ tests = ["tests", "*/tests"]
 [tool.coverage.run]
 branch = true
 source = ["src/heisskleber"]
-omit = ["tests/*"]
+omit = [
+    "tests/*",
+    "*/_debug.py",
+]
 
 [tool.coverage.report]
 show_missing = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [
+    "aiohttp>=3.13.1",
     "aiomqtt>=2.3.0",
     "pyserial>=3.5",
     "pyyaml>=6.0.2",
@@ -28,6 +29,7 @@ test = [
     "xdoctest>=1.2.0",
     "pytest-asyncio>=0.24.0",
     "freezegun>=1.5.1",
+    "pytest-httpserver>=1.1.3"
 ]
 docs = [
     "furo>=2024.8.6",

--- a/src/heisskleber/http/__init__.py
+++ b/src/heisskleber/http/__init__.py
@@ -1,0 +1,5 @@
+from .config import HTTPConf
+from .receiver import POSTReader
+from .sender import POSTSender
+
+__all__ = ["HTTPConf", "POSTReader", "POSTSender"]

--- a/src/heisskleber/http/__init__.py
+++ b/src/heisskleber/http/__init__.py
@@ -1,5 +1,5 @@
 from .config import HTTPConf
-from .receiver import POSTReader
-from .sender import POSTSender
+from .receiver import GETReader, POSTReader
+from .sender import GETSender, POSTSender
 
-__all__ = ["HTTPConf", "POSTReader", "POSTSender"]
+__all__ = ["GETReader", "GETSender", "HTTPConf", "POSTReader", "POSTSender"]

--- a/src/heisskleber/http/_compat.py
+++ b/src/heisskleber/http/_compat.py
@@ -1,8 +1,24 @@
 import asyncio
+import enum
 import sys
 from typing import Any
 
-if (sys.version_info.major, sys.version_info.minor) >= (3, 13):
+__all__ = [
+    "QueueShutDown",
+    "StrEnum",
+    "shutdown_queue",
+]
+
+if sys.version_info >= (3, 11):
+    StrEnum = enum.StrEnum
+
+else:
+
+    class StrEnum(str, enum.Enum):
+        __str__ = str.__str__
+
+
+if sys.version_info >= (3, 13):
 
     def shutdown_queue(queue: asyncio.Queue[Any], immediate: bool) -> None:
         queue.shutdown(immediate)  # type: ignore[attr-defined]
@@ -14,5 +30,5 @@ else:
     def shutdown_queue(queue: asyncio.Queue[Any], immediate: bool) -> None:
         return
 
-    class QueueShutDown(RuntimeError):  # type: ignore[no-redef] # noqa: N818
+    class QueueShutDown(RuntimeError):  # noqa: N818
         """Dummy Exception. Never raised nor caught."""

--- a/src/heisskleber/http/_compat.py
+++ b/src/heisskleber/http/_compat.py
@@ -4,14 +4,14 @@ from typing import Any
 
 if (sys.version_info.major, sys.version_info.minor) >= (3, 13):
 
-    def _shutdown_queue(queue: asyncio.Queue[Any], immediate: bool) -> None:
+    def shutdown_queue(queue: asyncio.Queue[Any], immediate: bool) -> None:
         queue.shutdown(immediate)  # type: ignore[attr-defined]
 
     QueueShutDown = asyncio.queues.QueueShutDown  # type: ignore[attr-defined]
 
 else:
 
-    def _shutdown_queue(queue: asyncio.Queue[Any], immediate: bool) -> None:
+    def shutdown_queue(queue: asyncio.Queue[Any], immediate: bool) -> None:
         return
 
     class QueueShutDown(RuntimeError):  # type: ignore[no-redef] # noqa: N818

--- a/src/heisskleber/http/_debug.py
+++ b/src/heisskleber/http/_debug.py
@@ -50,18 +50,24 @@ async def debug_post_sender() -> None:
         await sender.send(data={"a": "b"})
 
 
+_GET_SENDER_CURL = 'curl --header "Content-Type: application/json" --request GET  "http://localhost:8080/"'
+
+
 async def debug_get_sender() -> None:
     """Query with e.g. curl:
 
     curl --header "Content-Type: application/json" \
     --request GET \
-    http://localhost:8080/?a=b
+    http://localhost:8080/
     """
     config = HTTPConf(host="localhost", port=8080)
     sender = GETSender(config=config, packer=JSONPacker())
     async with sender:
         await sender.send({"a": "b"})
         await sender._queue.join()
+
+
+_POST_READER_CURL = """curl --header "Content-Type: application/json" --request POST --data '{"username":"xyz","password":"xyz"}' http://localhost:8080/"""
 
 
 async def debug_post_reader() -> None:
@@ -95,12 +101,10 @@ def main() -> int:
             run = debug_post_sender
         case "3":
             run = debug_get_sender
-            print('curl --header "Content-Type: application/json" --request GET  "http://localhost:8080/?a=b"')
+            print(_GET_SENDER_CURL)
         case "4":
             run = debug_post_reader
-            print(
-                """curl --header "Content-Type: application/json" --request POST --data '{"username":"xyz","password":"xyz"}' http://localhost:8080/"""
-            )
+            print(_POST_READER_CURL)
         case _:
             return 1
 

--- a/src/heisskleber/http/_debug.py
+++ b/src/heisskleber/http/_debug.py
@@ -1,0 +1,112 @@
+# ruff: noqa: T201 D415
+import asyncio
+import sys
+from typing import Any
+
+from aiohttp import web
+
+from heisskleber.core.packer import JSONPacker
+from heisskleber.core.unpacker import JSONUnpacker
+from heisskleber.http.config import HTTPConf
+from heisskleber.http.receiver import GETReader, POSTReader
+from heisskleber.http.sender import GETSender, POSTSender
+
+
+def debug_server(_: Any) -> web.Application:
+    """Start from commandline:
+
+    python -m aiohttp.web -H localhost -P 8080 "heisskleber.http._debug:debug_server"
+    """
+
+    async def handle_get(request: web.Request) -> web.Response:
+        print(request)
+        print(await request.read())
+        return web.json_response({"Hello": "World"}, status=200)
+
+    async def handle_post(request: web.Request) -> web.Response:
+        print(request)
+        print(await request.read())
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_route("GET", "/", handle_get)
+    app.router.add_route("POST", "/", handle_post)
+    return app
+
+
+async def debug_get_reader() -> None:
+    """Make sure debug_server is running before running this."""
+    config = HTTPConf(host="localhost", port=8080)
+    reader = GETReader(config=config, unpacker=JSONUnpacker())
+    async with reader:
+        print(await reader.receive(params={"a": "b"}))
+
+
+async def debug_post_sender() -> None:
+    """Make sure debug_server is running before running this."""
+    config = HTTPConf(host="localhost", port=8080)
+    sender = POSTSender(config=config, packer=JSONPacker())
+    async with sender:
+        await sender.send(data={"a": "b"})
+
+
+async def debug_get_sender() -> None:
+    """Query with e.g. curl:
+
+    curl --header "Content-Type: application/json" \
+    --request GET \
+    http://localhost:8080/?a=b
+    """
+    config = HTTPConf(host="localhost", port=8080)
+    sender = GETSender(config=config, packer=JSONPacker())
+    async with sender:
+        await sender.send({"a": "b"})
+        await sender._queue.join()
+
+
+async def debug_post_reader() -> None:
+    """Query with e.g. curl:
+
+    curl --header "Content-Type: application/json" \
+    --request POST \
+    --data '{"username":"xyz","password":"xyz"}' \
+    http://localhost:8080/
+    """
+    config = HTTPConf(host="localhost", port=8080)
+    reader = POSTReader(config=config, unpacker=JSONUnpacker())
+    async with reader:
+        print(await reader.receive())
+
+
+def main() -> int:
+    print("Select mode:")
+    print("Requiring running debug server:")
+    print('python -m aiohttp.web -H localhost -P 8080 "heisskleber.http._debug:debug_server"')
+    print("(1) GetReader")
+    print("(2) PostSender")
+    print("Query using e.g. curl:")
+    print("(3) GetSender")
+    print("(4) PostReader")
+    answer = input()
+    match answer:
+        case "1":
+            run = debug_get_reader
+        case "2":
+            run = debug_post_sender
+        case "3":
+            run = debug_get_sender
+            print('curl --header "Content-Type: application/json" --request GET  "http://localhost:8080/?a=b"')
+        case "4":
+            run = debug_post_reader
+            print(
+                """curl --header "Content-Type: application/json" --request POST --data '{"username":"xyz","password":"xyz"}' http://localhost:8080/"""
+            )
+        case _:
+            return 1
+
+    asyncio.run(run())
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/heisskleber/http/config.py
+++ b/src/heisskleber/http/config.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
-from enum import StrEnum
 
 from heisskleber.core import BaseConf
+from heisskleber.http._compat import StrEnum
 
 __all__ = ["HTTPConf"]
 

--- a/src/heisskleber/http/config.py
+++ b/src/heisskleber/http/config.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+from enum import StrEnum
+
+from heisskleber.core import BaseConf
+
+__all__ = ["HTTPConf"]
+
+
+@dataclass
+class HTTPConf(BaseConf):
+    """Configuration dataclass for HTTP connections."""
+
+    class Proto(StrEnum):  # noqa: D106
+        HTTP = "http"
+        HTTPS = "https"
+
+    host: str = "localhost"
+    port: int = 8080
+    protocol: Proto = Proto.HTTP
+    url_path: str = "/"
+    max_buffer_size: int = 100

--- a/src/heisskleber/http/receiver.py
+++ b/src/heisskleber/http/receiver.py
@@ -11,6 +11,7 @@ from aiohttp.web_response import Response
 
 from heisskleber.core import Receiver, Unpacker
 from heisskleber.http.config import HTTPConf
+from heisskleber.http.util import QueueShutDown, _shutdown_queue
 
 __all__ = ["GETReader", "POSTReader"]
 
@@ -44,7 +45,7 @@ class POSTReader(Receiver[T]):
             self._queue.put_nowait(data)
         except asyncio.queues.QueueFull:
             return web.Response(text="Queue is full. Try again later.", status=507)
-        except asyncio.queues.QueueShutDown:  # type: ignore[attr-defined]
+        except QueueShutDown:
             return web.Response(text="Receiver not ready or already stopped.", status=500)
 
         return web.Response(text="Received data.", status=200)
@@ -74,7 +75,7 @@ class POSTReader(Receiver[T]):
             except asyncio.TimeoutError:
                 pass
             finally:
-                self._queue.shutdown(immediate=True)  # type: ignore[attr-defined]
+                _shutdown_queue(self._queue, immediate=True)
 
 
 class GETReader(Receiver[T]):

--- a/src/heisskleber/http/receiver.py
+++ b/src/heisskleber/http/receiver.py
@@ -1,8 +1,11 @@
 # a source that returns POSTed data
 import asyncio
 import logging
+import sys
+from collections.abc import Mapping
 from typing import Any, TypeVar
 
+import aiohttp
 from aiohttp import web
 from aiohttp.web_request import Request
 from aiohttp.web_response import Response
@@ -11,7 +14,7 @@ from heisskleber.core import Receiver, Unpacker
 from heisskleber.core.unpacker import JSONUnpacker
 from heisskleber.http.config import HTTPConf
 
-__all__ = ["POSTReader"]
+__all__ = ["GETReader", "POSTReader"]
 
 
 T = TypeVar("T")
@@ -29,9 +32,9 @@ class POSTReader(Receiver[T]):
         self.config = config
         self.unpacker = unpacker
         self._queue: asyncio.queues.Queue[bytes] = asyncio.queues.Queue(maxsize=config.max_buffer_size)
+        self._runner: web.AppRunner | None = None
 
-    def __repr__(self) -> str:
-        """Return string representation of HTTP Source class."""
+    def __repr__(self) -> str:  # noqa: D105
         return f"{self.__class__.__name__}({self.config!r}. {self.unpacker!r})"
 
     async def _handle(self, request: Request) -> Response:
@@ -55,27 +58,64 @@ class POSTReader(Receiver[T]):
         return data, extra
 
     async def start(self) -> None:
-        """Start the AppRunner to listen for GET requests."""
+        """Start the AppRunner to listen for POST requests."""
         app = web.Application()
         app.add_routes([web.post(self.config.url_path, self._handle)])
-        self.runner = web.AppRunner(app)
-        await self.runner.setup()
-        self.site = web.TCPSite(self.runner, self.config.host, self.config.port)
-        await self.site.start()
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, self.config.host, self.config.port)
+        await site.start()
 
     async def stop(self) -> None:
         """Stop the AppRunner."""
-        await self.runner.cleanup()
-        try:
-            async with asyncio.timeout(5):
-                await self._queue.join()
-        except asyncio.TimeoutError:
-            pass
-        finally:
-            self._queue.shutdown(immediate=True)  # type: ignore[attr-defined]
+        if self._runner is not None:
+            await self._runner.cleanup()
+            try:
+                async with asyncio.timeout(5):
+                    await self._queue.join()
+            except asyncio.TimeoutError:
+                pass
+            finally:
+                self._queue.shutdown(immediate=True)  # type: ignore[attr-defined]
 
 
-async def _try_out() -> None:
+class GETReader(Receiver[T]):
+    """Asynchronous GET source."""
+
+    def __init__(
+        self,
+        config: HTTPConf,
+        unpacker: Unpacker[T],
+    ) -> None:
+        self.config = config
+        self.unpacker = unpacker
+        self._session: aiohttp.ClientSession | None = None
+
+    def __repr__(self) -> str:  # noqa: D105
+        return f"{self.__class__.__name__}({self.config!r}. {self.unpacker!r})"
+
+    async def receive(self, params: Mapping[str, str] | None = None, **kwargs: Any) -> tuple[T, dict[str, Any]]:
+        """Get the next data."""
+        if self._session is None:
+            await self.start()
+        assert self._session is not None  # noqa: S101 to satisfy mypy
+        url = f"{self.config.protocol}://{self.config.host}:{self.config.port}{self.config.url_path}"
+        response = await self._session.get(url, params=params)
+        response.raise_for_status()
+        data, extra = self.unpacker(await response.read())
+        return data, extra
+
+    async def start(self) -> None:
+        """Setup session."""
+        self._session = aiohttp.ClientSession()
+
+    async def stop(self) -> None:
+        """Close the session."""
+        if self._session is not None:
+            await self._session.close()
+
+
+async def _try_out_post_reader() -> None:
     config = HTTPConf(host="localhost", port=8080)
     reader = POSTReader(config=config, unpacker=JSONUnpacker())
     async with reader:
@@ -87,5 +127,42 @@ async def _try_out() -> None:
 #   --data '{"username":"xyz","password":"xyz"}' \
 #   http://localhost:8080/
 
+
+async def _try_out_get_reader() -> None:
+    config = HTTPConf(host="localhost", port=8080)
+    reader = GETReader(config=config, unpacker=JSONUnpacker())
+    async with reader:
+        print(await reader.receive(params={"a": "b"}))  # noqa: T201
+
+
+# python -m aiohttp.web -H localhost -P 8080 "heisskleber.http.receiver:_debug_app"
+def _debug_server(_: Any) -> web.Application:
+    async def _handler(request: web.Request) -> web.Response:
+        print(request)  # noqa: T201
+        print(await request.read())  # noqa: T201
+        return web.json_response({"Hello": "World"}, status=200)
+
+    app = web.Application()
+    app.router.add_route("*", "/", _handler)
+    return app
+
+
+def _main() -> int:
+    print("Select mode:")  # noqa: T201
+    print("(1) PostReader")  # noqa: T201
+    print("(2) GetReader")  # noqa: T201
+    answer = input()
+    match answer:
+        case "1":
+            run = _try_out_post_reader
+        case "2":
+            run = _try_out_get_reader
+        case _:
+            return 1
+
+    asyncio.run(run())
+    return 0
+
+
 if __name__ == "__main__":
-    asyncio.run(_try_out())
+    sys.exit(_main())

--- a/src/heisskleber/http/receiver.py
+++ b/src/heisskleber/http/receiver.py
@@ -1,7 +1,6 @@
 # a source that returns POSTed data
 import asyncio
 import logging
-import sys
 from collections.abc import Mapping
 from typing import Any, TypeVar
 
@@ -11,7 +10,6 @@ from aiohttp.web_request import Request
 from aiohttp.web_response import Response
 
 from heisskleber.core import Receiver, Unpacker
-from heisskleber.core.unpacker import JSONUnpacker
 from heisskleber.http.config import HTTPConf
 
 __all__ = ["GETReader", "POSTReader"]
@@ -113,56 +111,3 @@ class GETReader(Receiver[T]):
         """Close the session."""
         if self._session is not None:
             await self._session.close()
-
-
-async def _try_out_post_reader() -> None:
-    config = HTTPConf(host="localhost", port=8080)
-    reader = POSTReader(config=config, unpacker=JSONUnpacker())
-    async with reader:
-        print(await reader.receive())  # noqa: T201
-
-
-# curl --header "Content-Type: application/json" \
-#   --request POST \
-#   --data '{"username":"xyz","password":"xyz"}' \
-#   http://localhost:8080/
-
-
-async def _try_out_get_reader() -> None:
-    config = HTTPConf(host="localhost", port=8080)
-    reader = GETReader(config=config, unpacker=JSONUnpacker())
-    async with reader:
-        print(await reader.receive(params={"a": "b"}))  # noqa: T201
-
-
-# python -m aiohttp.web -H localhost -P 8080 "heisskleber.http.receiver:_debug_app"
-def _debug_server(_: Any) -> web.Application:
-    async def _handler(request: web.Request) -> web.Response:
-        print(request)  # noqa: T201
-        print(await request.read())  # noqa: T201
-        return web.json_response({"Hello": "World"}, status=200)
-
-    app = web.Application()
-    app.router.add_route("*", "/", _handler)
-    return app
-
-
-def _main() -> int:
-    print("Select mode:")  # noqa: T201
-    print("(1) PostReader")  # noqa: T201
-    print("(2) GetReader")  # noqa: T201
-    answer = input()
-    match answer:
-        case "1":
-            run = _try_out_post_reader
-        case "2":
-            run = _try_out_get_reader
-        case _:
-            return 1
-
-    asyncio.run(run())
-    return 0
-
-
-if __name__ == "__main__":
-    sys.exit(_main())

--- a/src/heisskleber/http/receiver.py
+++ b/src/heisskleber/http/receiver.py
@@ -1,0 +1,91 @@
+# a source that returns POSTed data
+import asyncio
+import logging
+from typing import Any, TypeVar
+
+from aiohttp import web
+from aiohttp.web_request import Request
+from aiohttp.web_response import Response
+
+from heisskleber.core import Receiver, Unpacker
+from heisskleber.core.unpacker import JSONUnpacker
+from heisskleber.http.config import HTTPConf
+
+__all__ = ["POSTReader"]
+
+
+T = TypeVar("T")
+logger = logging.getLogger("heisskleber.http")
+
+
+class POSTReader(Receiver[T]):
+    """Asynchronous POST source."""
+
+    def __init__(
+        self,
+        config: HTTPConf,
+        unpacker: Unpacker[T],
+    ) -> None:
+        self.config = config
+        self.unpacker = unpacker
+        self._queue: asyncio.queues.Queue[bytes] = asyncio.queues.Queue(maxsize=config.max_buffer_size)
+
+    def __repr__(self) -> str:
+        """Return string representation of HTTP Source class."""
+        return f"{self.__class__.__name__}({self.config!r}. {self.unpacker!r})"
+
+    async def _handle(self, request: Request) -> Response:
+        data = await request.read()
+        if not len(data):
+            return web.Response(text="Empty Body send.", status=400)
+
+        try:
+            self._queue.put_nowait(data)
+        except asyncio.queues.QueueFull:
+            return web.Response(text="Queue is full. Try again later.", status=507)
+        except asyncio.queues.QueueShutDown:  # type: ignore[attr-defined]
+            return web.Response(text="Receiver not ready or already stopped.", status=500)
+
+        return web.Response(text="Received data.", status=200)
+
+    async def receive(self, **kwargs: Any) -> tuple[T, dict[str, Any]]:
+        """Get the next data."""
+        data, extra = self.unpacker(await self._queue.get())
+        self._queue.task_done()
+        return data, extra
+
+    async def start(self) -> None:
+        """Start the AppRunner to listen for GET requests."""
+        app = web.Application()
+        app.add_routes([web.post(self.config.url_path, self._handle)])
+        self.runner = web.AppRunner(app)
+        await self.runner.setup()
+        self.site = web.TCPSite(self.runner, self.config.host, self.config.port)
+        await self.site.start()
+
+    async def stop(self) -> None:
+        """Stop the AppRunner."""
+        await self.runner.cleanup()
+        try:
+            async with asyncio.timeout(5):
+                await self._queue.join()
+        except asyncio.TimeoutError:
+            pass
+        finally:
+            self._queue.shutdown(immediate=True)  # type: ignore[attr-defined]
+
+
+async def _try_out() -> None:
+    config = HTTPConf(host="localhost", port=8080)
+    reader = POSTReader(config=config, unpacker=JSONUnpacker())
+    async with reader:
+        print(await reader.receive())  # noqa: T201
+
+
+# curl --header "Content-Type: application/json" \
+#   --request POST \
+#   --data '{"username":"xyz","password":"xyz"}' \
+#   http://localhost:8080/
+
+if __name__ == "__main__":
+    asyncio.run(_try_out())

--- a/src/heisskleber/http/receiver.py
+++ b/src/heisskleber/http/receiver.py
@@ -10,8 +10,8 @@ from aiohttp.web_request import Request
 from aiohttp.web_response import Response
 
 from heisskleber.core import Receiver, Unpacker
+from heisskleber.http._compat import QueueShutDown, shutdown_queue
 from heisskleber.http.config import HTTPConf
-from heisskleber.http.util import QueueShutDown, _shutdown_queue
 
 __all__ = ["GETReader", "POSTReader"]
 
@@ -75,7 +75,7 @@ class POSTReader(Receiver[T]):
             except asyncio.TimeoutError:
                 pass
             finally:
-                _shutdown_queue(self._queue, immediate=True)
+                shutdown_queue(self._queue, immediate=True)
 
 
 class GETReader(Receiver[T]):

--- a/src/heisskleber/http/receiver.py
+++ b/src/heisskleber/http/receiver.py
@@ -70,8 +70,7 @@ class POSTReader(Receiver[T]):
         if self._runner is not None:
             await self._runner.cleanup()
             try:
-                async with asyncio.timeout(5):
-                    await self._queue.join()
+                await asyncio.wait_for(self._queue.join(), 5)
             except asyncio.TimeoutError:
                 pass
             finally:

--- a/src/heisskleber/http/sender.py
+++ b/src/heisskleber/http/sender.py
@@ -1,0 +1,73 @@
+#  a sink interface that POSTs data
+import asyncio
+import logging
+from typing import Any, TypeVar
+
+import aiohttp
+from aiohttp import web
+
+from heisskleber.core import Packer, Sender
+from heisskleber.core.packer import JSONPacker
+from heisskleber.http.config import HTTPConf
+
+__all__ = ["POSTSender"]
+
+T = TypeVar("T")
+
+
+logger = logging.getLogger("heisskleber.http")
+
+
+class POSTSender(Sender[T]):
+    """HTTP POST Sender."""
+
+    def __init__(self, config: HTTPConf, packer: Packer[T]) -> None:
+        self.config = config
+        self.packer = packer
+        self._session: aiohttp.ClientSession | None = None
+
+    async def send(self, data: T, **kwargs: Any) -> None:
+        """POST data to url."""
+        # TODO headers?
+        if self._session is None:
+            await self.start()
+        assert self._session is not None  # noqa: S101 to satisfy mypy
+        payload = self.packer(data)
+        url = f"{self.config.protocol}://{self.config.host}:{self.config.port}{self.config.url_path}"
+        await self._session.post(url, data=payload)
+
+    def __repr__(self) -> str:
+        """Return string representation of the HTTP POST sink object."""
+        return f"{self.__class__.__name__}({self.config}, {self.packer})"
+
+    async def start(self) -> None:
+        """Setup session."""
+        self._session = aiohttp.ClientSession()
+
+    async def stop(self) -> None:
+        """Close the session."""
+        if self._session is not None:
+            await self._session.close()
+
+
+async def _try_out() -> None:
+    config = HTTPConf(host="localhost", port=8080)
+    sender = POSTSender(config=config, packer=JSONPacker())
+    async with sender:
+        await sender.send(data={"a": "b"})
+
+
+# python -m aiohttp.web -H localhost -P 8080 "heisskleber.http.sender:_debug_app"
+def _debug_app(_: Any) -> web.Application:
+    async def _handler(request: web.Request) -> web.Response:
+        print(request)  # noqa: T201
+        print(await request.read())  # noqa: T201
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_route("*", "/", _handler)
+    return app
+
+
+if __name__ == "__main__":
+    asyncio.run(_try_out())

--- a/src/heisskleber/http/sender.py
+++ b/src/heisskleber/http/sender.py
@@ -9,8 +9,8 @@ from aiohttp.web_request import Request
 from aiohttp.web_response import Response
 
 from heisskleber.core import Packer, Sender
+from heisskleber.http._compat import QueueShutDown, shutdown_queue
 from heisskleber.http.config import HTTPConf
-from heisskleber.http.util import QueueShutDown, _shutdown_queue
 
 __all__ = ["GETSender", "POSTSender"]
 
@@ -108,4 +108,4 @@ class GETSender(Sender[T]):
             except asyncio.TimeoutError:
                 pass
             finally:
-                _shutdown_queue(self._queue, immediate=True)
+                shutdown_queue(self._queue, immediate=True)

--- a/src/heisskleber/http/sender.py
+++ b/src/heisskleber/http/sender.py
@@ -1,7 +1,6 @@
 #  a sink interface that POSTs data
 import asyncio
 import logging
-import sys
 from typing import Any, TypeVar
 
 import aiohttp
@@ -10,7 +9,6 @@ from aiohttp.web_request import Request
 from aiohttp.web_response import Response
 
 from heisskleber.core import Packer, Sender
-from heisskleber.core.packer import JSONPacker
 from heisskleber.http.config import HTTPConf
 
 __all__ = ["GETSender", "POSTSender"]
@@ -110,56 +108,3 @@ class GETSender(Sender[T]):
                 pass
             finally:
                 self._queue.shutdown(immediate=True)  # type: ignore[attr-defined]
-
-
-async def _try_out_post_sender() -> None:
-    config = HTTPConf(host="localhost", port=8080)
-    sender = POSTSender(config=config, packer=JSONPacker())
-    async with sender:
-        await sender.send(data={"a": "b"})
-
-
-# python -m aiohttp.web -H localhost -P 8080 "heisskleber.http.sender:_debug_app"
-def _debug_server(_: Any) -> web.Application:
-    async def _handler(request: web.Request) -> web.Response:
-        print(request)  # noqa: T201
-        print(await request.read())  # noqa: T201
-        return web.Response()
-
-    app = web.Application()
-    app.router.add_route("*", "/", _handler)
-    return app
-
-
-async def _try_out_get_sender() -> None:
-    config = HTTPConf(host="localhost", port=8080)
-    sender = GETSender(config=config, packer=JSONPacker())
-    async with sender:
-        await sender.send({"a": "b"})
-        await sender._queue.join()
-
-
-# curl --header "Content-Type: application/json" \
-#   --request GET \
-#   http://localhost:8080/?a=b
-
-
-def _main() -> int:
-    print("Select mode:")  # noqa: T201
-    print("(1) PostSender")  # noqa: T201
-    print("(2) GetSender")  # noqa: T201
-    answer = input()
-    match answer:
-        case "1":
-            run = _try_out_post_sender
-        case "2":
-            run = _try_out_get_sender
-        case _:
-            return 1
-
-    asyncio.run(run())
-    return 0
-
-
-if __name__ == "__main__":
-    sys.exit(_main())

--- a/src/heisskleber/http/sender.py
+++ b/src/heisskleber/http/sender.py
@@ -10,6 +10,7 @@ from aiohttp.web_response import Response
 
 from heisskleber.core import Packer, Sender
 from heisskleber.http.config import HTTPConf
+from heisskleber.http.util import QueueShutDown, _shutdown_queue
 
 __all__ = ["GETSender", "POSTSender"]
 
@@ -75,7 +76,7 @@ class GETSender(Sender[T]):
             self._queue.task_done()
         except asyncio.queues.QueueEmpty:
             return web.Response(text="No data available.", status=500)
-        except asyncio.queues.QueueShutDown:  # type: ignore[attr-defined]
+        except QueueShutDown:
             return web.Response(text="Sender not ready or already stopped.", status=500)
 
         if isinstance(data, str):
@@ -107,4 +108,4 @@ class GETSender(Sender[T]):
             except asyncio.TimeoutError:
                 pass
             finally:
-                self._queue.shutdown(immediate=True)  # type: ignore[attr-defined]
+                _shutdown_queue(self._queue, immediate=True)

--- a/src/heisskleber/http/sender.py
+++ b/src/heisskleber/http/sender.py
@@ -103,8 +103,7 @@ class GETSender(Sender[T]):
         if self._runner is not None:
             await self._runner.cleanup()
             try:
-                async with asyncio.timeout(5):
-                    await self._queue.join()
+                await asyncio.wait_for(self._queue.join(), 5)
             except asyncio.TimeoutError:
                 pass
             finally:

--- a/src/heisskleber/http/sender.py
+++ b/src/heisskleber/http/sender.py
@@ -1,16 +1,19 @@
 #  a sink interface that POSTs data
 import asyncio
 import logging
+import sys
 from typing import Any, TypeVar
 
 import aiohttp
 from aiohttp import web
+from aiohttp.web_request import Request
+from aiohttp.web_response import Response
 
 from heisskleber.core import Packer, Sender
 from heisskleber.core.packer import JSONPacker
 from heisskleber.http.config import HTTPConf
 
-__all__ = ["POSTSender"]
+__all__ = ["GETSender", "POSTSender"]
 
 T = TypeVar("T")
 
@@ -36,8 +39,7 @@ class POSTSender(Sender[T]):
         url = f"{self.config.protocol}://{self.config.host}:{self.config.port}{self.config.url_path}"
         await self._session.post(url, data=payload)
 
-    def __repr__(self) -> str:
-        """Return string representation of the HTTP POST sink object."""
+    def __repr__(self) -> str:  # noqa: D105
         return f"{self.__class__.__name__}({self.config}, {self.packer})"
 
     async def start(self) -> None:
@@ -50,7 +52,67 @@ class POSTSender(Sender[T]):
             await self._session.close()
 
 
-async def _try_out() -> None:
+class GETSender(Sender[T]):
+    """Asynchronous GET server."""
+
+    def __init__(
+        self,
+        config: HTTPConf,
+        packer: Packer[T],
+    ) -> None:
+        self.config = config
+        self.packer = packer
+        self._queue: asyncio.queues.Queue[str | bytes | bytearray] = asyncio.queues.Queue(
+            maxsize=config.max_buffer_size
+        )
+        self._runner: web.AppRunner | None = None
+
+    def __repr__(self) -> str:  # noqa: D105
+        return f"{self.__class__.__name__}({self.config!r}. {self.packer!r})"
+
+    async def _handle(self, _: Request) -> Response:
+        # TODO handle params / headers?
+        try:
+            data = self._queue.get_nowait()
+            self._queue.task_done()
+        except asyncio.queues.QueueEmpty:
+            return web.Response(text="No data available.", status=500)
+        except asyncio.queues.QueueShutDown:  # type: ignore[attr-defined]
+            return web.Response(text="Sender not ready or already stopped.", status=500)
+
+        if isinstance(data, str):
+            data = data.encode("utf-8")
+        elif isinstance(data, bytearray):
+            data = bytes(data)
+        return web.Response(body=data, status=200)
+
+    async def send(self, data: T, **kwargs: Any) -> None:
+        """Queue data to be queried by GET request."""
+        self._queue.put_nowait(self.packer(data))
+
+    async def start(self) -> None:
+        """Start the AppRunner to listen for GET requests."""
+        app = web.Application()
+        app.add_routes([web.get(self.config.url_path, self._handle)])
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, self.config.host, self.config.port)
+        await site.start()
+
+    async def stop(self) -> None:
+        """Stop the AppRunner."""
+        if self._runner is not None:
+            await self._runner.cleanup()
+            try:
+                async with asyncio.timeout(5):
+                    await self._queue.join()
+            except asyncio.TimeoutError:
+                pass
+            finally:
+                self._queue.shutdown(immediate=True)  # type: ignore[attr-defined]
+
+
+async def _try_out_post_sender() -> None:
     config = HTTPConf(host="localhost", port=8080)
     sender = POSTSender(config=config, packer=JSONPacker())
     async with sender:
@@ -58,7 +120,7 @@ async def _try_out() -> None:
 
 
 # python -m aiohttp.web -H localhost -P 8080 "heisskleber.http.sender:_debug_app"
-def _debug_app(_: Any) -> web.Application:
+def _debug_server(_: Any) -> web.Application:
     async def _handler(request: web.Request) -> web.Response:
         print(request)  # noqa: T201
         print(await request.read())  # noqa: T201
@@ -69,5 +131,35 @@ def _debug_app(_: Any) -> web.Application:
     return app
 
 
+async def _try_out_get_sender() -> None:
+    config = HTTPConf(host="localhost", port=8080)
+    sender = GETSender(config=config, packer=JSONPacker())
+    async with sender:
+        await sender.send({"a": "b"})
+        await sender._queue.join()
+
+
+# curl --header "Content-Type: application/json" \
+#   --request GET \
+#   http://localhost:8080/?a=b
+
+
+def _main() -> int:
+    print("Select mode:")  # noqa: T201
+    print("(1) PostSender")  # noqa: T201
+    print("(2) GetSender")  # noqa: T201
+    answer = input()
+    match answer:
+        case "1":
+            run = _try_out_post_sender
+        case "2":
+            run = _try_out_get_sender
+        case _:
+            return 1
+
+    asyncio.run(run())
+    return 0
+
+
 if __name__ == "__main__":
-    asyncio.run(_try_out())
+    sys.exit(_main())

--- a/src/heisskleber/http/util.py
+++ b/src/heisskleber/http/util.py
@@ -1,0 +1,18 @@
+import asyncio
+import sys
+from typing import Any
+
+if (sys.version_info.major, sys.version_info.minor) >= (3, 13):
+
+    def _shutdown_queue(queue: asyncio.Queue[Any], immediate: bool) -> None:
+        queue.shutdown(immediate)  # type: ignore[attr-defined]
+
+    QueueShutDown = asyncio.queues.QueueShutDown  # type: ignore[attr-defined]
+
+else:
+
+    def _shutdown_queue(queue: asyncio.Queue[Any], immediate: bool) -> None:
+        return
+
+    class QueueShutDown(RuntimeError):  # type: ignore[no-redef] # noqa: N818
+        """Dummy Exception. Never raised nor caught."""

--- a/tests/http/test_receiver.py
+++ b/tests/http/test_receiver.py
@@ -1,12 +1,14 @@
 import asyncio
 import json
+from typing import Literal, TypedDict
 from urllib.request import Request, urlopen
 
 import pytest
+from pytest_httpserver import HTTPServer, RequestMatcher
 
 from heisskleber.core.unpacker import JSONUnpacker
 from heisskleber.http.config import HTTPConf
-from heisskleber.http.receiver import POSTReader
+from heisskleber.http.receiver import GETReader, POSTReader
 
 
 def _make_request(request: Request) -> tuple[int, bytes]:
@@ -31,6 +33,29 @@ async def test_post_reader() -> None:
 
     assert status == 200
     assert msg == b"Received data."
+
+    assert len(received) == 2
+    assert received[0] == data
+    assert received[1] == {}
+
+
+class MatchArgs(TypedDict):
+    uri: str
+    method: Literal["GET"]
+
+
+@pytest.mark.asyncio
+async def test_get_reader(httpserver: HTTPServer) -> None:
+    data = {"a": "b"}
+    match_kwargs = MatchArgs(uri="/", method="GET")
+    httpserver.expect_oneshot_request(**match_kwargs).respond_with_json(data, status=200)
+    port = httpserver.port
+    config = HTTPConf(host="localhost", port=port)
+    reader = GETReader(config=config, unpacker=JSONUnpacker())
+    async with reader:
+        received = await reader.receive()
+
+    httpserver.assert_request_made(RequestMatcher(**match_kwargs))
 
     assert len(received) == 2
     assert received[0] == data

--- a/tests/http/test_receiver.py
+++ b/tests/http/test_receiver.py
@@ -1,0 +1,37 @@
+import asyncio
+import json
+from urllib.request import Request, urlopen
+
+import pytest
+
+from heisskleber.core.unpacker import JSONUnpacker
+from heisskleber.http.config import HTTPConf
+from heisskleber.http.receiver import POSTReader
+
+
+def _make_request(request: Request) -> tuple[int, bytes]:
+    with urlopen(request, timeout=1) as resp:  # noqa: S310
+        return resp.status, resp.read()
+
+
+@pytest.mark.asyncio
+async def test_post_reader() -> None:
+    port = 8080
+    url_path = "/"
+    config = HTTPConf(port=port, url_path=url_path)
+    reader = POSTReader(config=config, unpacker=JSONUnpacker())
+
+    data = {"a": "b"}
+    req = Request(f"http://localhost:{port}{url_path}", data=json.dumps(data).encode())
+    req.add_header("Content-Type", "application/json")
+
+    async with reader:
+        status, msg = await asyncio.to_thread(_make_request, req)
+        received = await reader.receive()
+
+    assert status == 200
+    assert msg == b"Received data."
+
+    assert len(received) == 2
+    assert received[0] == data
+    assert received[1] == {}

--- a/tests/http/test_sender.py
+++ b/tests/http/test_sender.py
@@ -1,0 +1,28 @@
+from typing import Literal, TypedDict
+
+import pytest
+from pytest_httpserver import HTTPServer, RequestMatcher
+
+from heisskleber.core.packer import JSONPacker
+from heisskleber.http.config import HTTPConf
+from heisskleber.http.sender import POSTSender
+
+
+class MatchArgs(TypedDict):
+    uri: str
+    method: Literal["POST"]
+    json: dict[str, str]
+
+
+@pytest.mark.asyncio
+async def test_post_sender(httpserver: HTTPServer) -> None:
+    data = {"a": "b"}
+    match_kwargs = MatchArgs(uri="/", method="POST", json=data)
+    (httpserver.expect_oneshot_request(**match_kwargs).respond_with_data("OK", status=200))
+    port = httpserver.port
+    config = HTTPConf(host="localhost", port=port)
+    sender = POSTSender(config=config, packer=JSONPacker())
+    async with sender:
+        await sender.send(data=data)
+
+    httpserver.assert_request_made(RequestMatcher(**match_kwargs))

--- a/tests/http/test_sender.py
+++ b/tests/http/test_sender.py
@@ -1,11 +1,14 @@
+import asyncio
+import json
 from typing import Literal, TypedDict
+from urllib.request import Request, urlopen
 
 import pytest
 from pytest_httpserver import HTTPServer, RequestMatcher
 
 from heisskleber.core.packer import JSONPacker
 from heisskleber.http.config import HTTPConf
-from heisskleber.http.sender import POSTSender
+from heisskleber.http.sender import GETSender, POSTSender
 
 
 class MatchArgs(TypedDict):
@@ -26,3 +29,26 @@ async def test_post_sender(httpserver: HTTPServer) -> None:
         await sender.send(data=data)
 
     httpserver.assert_request_made(RequestMatcher(**match_kwargs))
+
+
+def _make_request(request: Request) -> tuple[int, bytes]:
+    with urlopen(request, timeout=1) as resp:  # noqa: S310
+        return resp.status, resp.read()
+
+
+@pytest.mark.asyncio
+async def test_get_sender() -> None:
+    port = 8080
+    url_path = "/"
+    config = HTTPConf(port=port, url_path=url_path)
+    sender = GETSender(config=config, packer=JSONPacker())
+
+    data = {"a": "b"}
+    req = Request(f"http://localhost:{port}{url_path}")
+
+    async with sender:
+        await sender.send(data=data)
+        status, msg = await asyncio.to_thread(_make_request, req)
+
+    assert status == 200
+    assert msg == json.dumps({"a": "b"}).encode()


### PR DESCRIPTION
Relates to https://github.com/flucto-gmbh/heisskleber/issues/74. 

Adds two new sources: `GETReader` and `POSTReader` :
- `GETReader`: queries GET endpoint and provides the response. 
- `POSTReader`: spawns a webserver and provides the POSTed data

Adds two new sinks: `GETSender` and `POSTSender`:
- `GETSender`: spawns a webserver and provides buffered data via GET requests
- `POSTSender`: sends data to POST endpoint. 
